### PR TITLE
Bundle/ExuIO: add redirect to ExuInput and ExuOutput

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -68,11 +68,13 @@ class Dp1ToDp2IO extends XSBundle {
 
 class ExuInput extends XSBundle {
   val uop = new MicroOp
+  val redirect = new Redirect
   val src1, src2, src3 = UInt(XLEN.W)
 }
 
 class ExuOutput extends XSBundle {
   val uop = new MicroOp
+  val redirect = new Redirect
   val data = UInt(XLEN.W)
 }
 


### PR DESCRIPTION
  Redirect in ExuInput is used to flush the function unit itself.
  Redirect in ExuOutput is used to flush other function units.
  Just ROB, bru(can exec jal/jalr/csr instrs) and alu(can exec
branch instrs) can generate redirect.