### PR TITLE
freelist: init freelist without preg0

### DIFF
--- a/src/main/scala/xiangshan/backend/rename/FreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/FreeList.scala
@@ -19,7 +19,7 @@ class FreeList extends XSModule {
     val deallocPregs = Input(Vec(CommitWidth, UInt(PhyRegIdxWidth.W)))
   })
 
-  val freeList = RegInit(VecInit(Seq.tabulate(NRPhyRegs)(i => i.U(PhyRegIdxWidth.W))))
+  val freeList = RegInit(VecInit(Seq.tabulate(NRPhyRegs-1)(i => (i+1).U(PhyRegIdxWidth.W))))
   val headPtr = RegInit(0.U((PhyRegIdxWidth+1).W))
   val tailPtr = RegInit((1 << PhyRegIdxWidth).U((PhyRegIdxWidth+1).W))
 


### PR DESCRIPTION
由于rename机制现在还存在问题，为了能够运行dummy第一条指令，暂时把物理寄存器0号移出freelist。
这个改动只能保证第一条指令能够被正常提交，但仍然存在问题，比如0号寄存器之后会被回收。

这个commit之后，指令可以正确提交了