### PR TITLE
Log: use implict module name instead implict module

### DIFF
--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -62,7 +62,7 @@ trait HasXSParameter {
 }
 
 trait HasXSLog { this: Module =>
-  implicit val _implict_module = this
+  implicit val moduleName: String = this.name
 }
 
 abstract class XSModule extends Module

--- a/src/main/scala/xiangshan/utils/LogUtils.scala
+++ b/src/main/scala/xiangshan/utils/LogUtils.scala
@@ -35,8 +35,8 @@ object XSLog {
 
   def apply(debugLevel: XSLogLevel)
            (cond: Bool, pable: Printable)
-           (implicit m: Module): Any = {
-    val commonInfo = p"[$debugLevel][time=${GTimer()}] ${m.name}: "
+           (implicit name: String): Any = {
+    val commonInfo = p"[$debugLevel][time=${GTimer()}] $name: "
     when (debugLevel.id.U >= xsLogLevel && cond && displayLog) {
       printf(commonInfo + pable)
     }
@@ -45,12 +45,12 @@ object XSLog {
 
 sealed abstract class LogHelper(val logLevel: XSLogLevel) extends HasXSParameter {
 
-  def apply(cond: Bool, fmt: String, data: Bits*)(implicit m: Module): Any =
+  def apply(cond: Bool, fmt: String, data: Bits*)(implicit name: String): Any =
     apply(cond, Printable.pack(fmt, data:_*))
-  def apply(cond: Bool, pable: Printable)(implicit m: Module): Any = XSLog(logLevel)(cond, pable)
-  def apply(fmt: String, data: Bits*)(implicit m: Module): Any =
+  def apply(cond: Bool, pable: Printable)(implicit name: String): Any = XSLog(logLevel)(cond, pable)
+  def apply(fmt: String, data: Bits*)(implicit name: String): Any =
     apply(true.B, Printable.pack(fmt, data:_*))
-  def apply(pable: Printable)(implicit m: Module): Any = XSLog(logLevel)(true.B, pable)
+  def apply(pable: Printable)(implicit name: String): Any = XSLog(logLevel)(true.B, pable)
 
   // Do not use that unless you have valid reasons
   def apply(cond: Bool = true.B)(body: => Unit): Any =


### PR DESCRIPTION
使用implict module会污染生成的fir中的模块名