### PR TITLE
Ibuffer:Fixed instr error after flush

### DIFF
--- a/src/main/scala/xiangshan/frontend/FakeIFU.scala
+++ b/src/main/scala/xiangshan/frontend/FakeIFU.scala
@@ -69,7 +69,7 @@ class FakeIFU extends XSModule with HasIFUConst {
   fakeCache.io.addr := pc
 
   io.fetchPacket.valid := !io.redirect.valid
-  io.fetchPacket.bits.mask := Fill(FetchWidth, 1.U(1.W)) << pc(2+log2Up(FetchWidth)-1, 2)
+  io.fetchPacket.bits.mask := Fill(FetchWidth*2, 1.U(1.W)) << pc(2+log2Up(FetchWidth)-1, 1)
   io.fetchPacket.bits.pc := pc
   io.fetchPacket.bits.instrs := fakeCache.io.rdata
 

--- a/src/main/scala/xiangshan/frontend/Ibuffer.scala
+++ b/src/main/scala/xiangshan/frontend/Ibuffer.scala
@@ -117,9 +117,9 @@ class Ibuffer extends XSModule {
   when(io.flush) {
     for(i <- 0 until IBufSize) {
       ibuf_valid(i) := false.B
-      head_ptr := 0.U
-      tail_ptr := 0.U
     }
+    head_ptr := 0.U
+    tail_ptr := 0.U
 
     for(i <- 0 until DecodeWidth) {
       io.out(i).valid := false.B


### PR DESCRIPTION
修复了在跳转指令清空缓存后输出指令为全零的错误