### PR TITLE
Ibuffer: Change XSLog information

### DIFF
--- a/src/main/scala/xiangshan/frontend/Ibuffer.scala
+++ b/src/main/scala/xiangshan/frontend/Ibuffer.scala
@@ -85,8 +85,8 @@ class Ibuffer extends XSModule {
           io.out(i).valid := false.B
         }
       }.otherwise {
-        io.out(i).bits.instr := 0.U
-        io.out(i).bits.pc := 0.U
+        io.out(i).bits.instr := Cat(ibuf(head_ptr + (i<<1).U + 1.U), ibuf(head_ptr + (i<<1).U))
+        io.out(i).bits.pc := ibuf_pc(head_ptr + (i<<1).U)
         io.out(i).bits.isRVC := false.B
         io.out(i).valid := false.B
       }
@@ -128,6 +128,7 @@ class Ibuffer extends XSModule {
 
   //Debug Info
 //  XSDebug(enqValid, "Enque:\n")
+//  XSDebug(p"v=${io.in.valid}  r=${io.in.ready}\n")
 //  for(i <- 0 until FetchWidth) {
 //    XSDebug(enqValid, p"${Binary(io.in.bits.instrs(i))}\n")
 //  }
@@ -135,8 +136,8 @@ class Ibuffer extends XSModule {
   XSInfo(io.flush, "Flush signal received, clear buffer\n")
   XSDebug(deqValid, "Deque:\n")
   for(i <- 0 until DecodeWidth) {
-    XSDebug(deqValid, p"${Binary(io.out(i).bits.instr)}  PC=${Hexadecimal(io.out(i).bits.pc)}\n")
+    XSDebug(deqValid, p"${Binary(io.out(i).bits.instr)}  PC=${Hexadecimal(io.out(i).bits.pc)}  v=${io.out(i).valid}  r=${io.out(i).ready}\n")
   }
-//  XSDebug(enqValid, p"last_head_ptr=$head_ptr  last_tail_ptr=$tail_ptr\n")
+  XSDebug(enqValid, p"last_head_ptr=$head_ptr  last_tail_ptr=$tail_ptr\n")
 //  XSInfo(full, "Queue is full\n")
 }


### PR DESCRIPTION
给Ibuffer调试信息添加了valid和ready位，且当io.out.ready不为true时会重复输出缓存中前6条32位指令，当缓存为空时会输出全0