### PR TITLE
Makefile: support parallel build with emu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ $(REF_SO):
 	$(MAKE) -C $(NEMU_HOME) ISA=riscv64 SHARE=1
 
 $(EMU): $(EMU_MK) $(EMU_DEPS) $(EMU_HEADERS) $(REF_SO)
-	CPPFLAGS=-DREF_SO=\\\"$(REF_SO)\\\" $(MAKE) -C $(dir $(EMU_MK)) -f $(abspath $(EMU_MK))
+	CPPFLAGS=-DREF_SO=\\\"$(REF_SO)\\\" $(MAKE) VM_PARALLEL_BUILDS=1 -C $(dir $(EMU_MK)) -f $(abspath $(EMU_MK))
 
 SEED = -s $(shell seq 1 10000 | shuf | head -n 1)
 


### PR DESCRIPTION
* Previously there is a cpp file called xxx__ALLcls.cpp, which includes
  nearly all other cpp files. Such a big cpp file will be compiled. And
  it can not leverage parallel jobs with Makefile.
* To enbale parallel build, we should pass VM_PARALLEL_BUILDS=1 to the
  Makefile to generate emu.