### PR TITLE
bump chisel to 3.3.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ resolvers ++= Seq(
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel3" -> "3.2-SNAPSHOT",
+  "chisel3" -> "3.3.2",
   "chisel-iotesters" -> "[1.2.5,1.3-SNAPSHOT["
   )
 

--- a/build.sc
+++ b/build.sc
@@ -25,7 +25,7 @@ trait HasXsource211 extends ScalaModule {
 
 trait HasChisel3 extends ScalaModule {
   override def ivyDeps = Agg(
-    ivy"edu.berkeley.cs::chisel3:3.3.1"
+    ivy"edu.berkeley.cs::chisel3:3.3.2"
  )
 }
 


### PR DESCRIPTION
* This will also bump firrtl to 1.3.2. It seems that the performance of
  firrtl compile time is greatly improved. On 9700k, it is improved from
  218104.5 ms to 135609.5 ms.