### PR TITLE
disable l2cache/l2prefetcher, support remote run-emu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ IMAGE ?= temp
 
 # remote machine with high frequency to speedup verilog generation
 REMOTE ?= localhost
-REMOTE_PREFIX ?= /nfs/24/$(abspath .)/
+REMOTE_PREFIX ?= /nfs/24
+REMOTE_PRJ_HOME = $(REMOTE_PREFIX)/$(abspath .)/
 
 .DEFAULT_GOAL = verilog
 
@@ -48,7 +49,7 @@ $(SIM_TOP_V): $(SCALA_FILE) $(TEST_FILE)
 ifeq ($(REMOTE),localhost)
 	mill chiselModule.test.runMain $(SIMTOP) -X verilog -td $(@D) --output-file $(@F)
 else
-	ssh $(REMOTE) "cd $(REMOTE_PREFIX) && mill chiselModule.test.runMain $(SIMTOP) -X verilog -td $(@D) --output-file $(@F)"
+	ssh $(REMOTE) "cd $(REMOTE_PRJ_HOME) && mill chiselModule.test.runMain $(SIMTOP) -X verilog -td $(@D) --output-file $(@F)"
 endif
 
 
@@ -108,7 +109,7 @@ emu: $(EMU)
 ifeq ($(REMOTE),localhost)
 	@$(EMU) -i $(IMAGE) $(SEED) -b $(B) -e $(E)
 else
-	ssh $(REMOTE) "cd $(REMOTE_PREFIX) && $(EMU) -i $(IMAGE) $(SEED) -b $(B) -e $(E)"
+	ssh $(REMOTE) "cd $(REMOTE_PRJ_HOME) && $(EMU) -i $(REMOTE_PREFIX)/$(IMAGE) $(SEED) -b $(B) -e $(E)"
 endif
 
 cache:

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -10,9 +10,9 @@ import chisel3.util.experimental.BoringUtils
 import xiangshan.{XSConfig, XSCore}
 
 trait HasSoCParameter {
-  val EnableILA = true
-  val HasL2cache = true
-  val HasPrefetch = true
+  val EnableILA = false
+  val HasL2cache = false
+  val HasPrefetch = false
 }
 
 class ILABundle extends Bundle {}

--- a/src/test/csrc/emu.h
+++ b/src/test/csrc/emu.h
@@ -131,7 +131,7 @@ class Emulator {
     uint32_t lasttime = 0;
     uint64_t lastcommit = n;
     int hascommit = 0;
-    const int stuck_limit = 100;
+    const int stuck_limit = 500;
     
     static uint32_t wdst[DIFFTEST_WIDTH];
     static uint64_t wdata[DIFFTEST_WIDTH];


### PR DESCRIPTION
1. disable l2 cache and prefetcher to increase emulation speed
2. support running emu on remote machine (fix remote image directory)