### PR TITLE
Optimize pipeline

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -25,7 +25,7 @@ class FetchPacket extends XSBundle {
 
 class ValidUndirectioned[T <: Data](gen: T) extends Bundle {
   val valid = Bool()
-  val bits = gen.asInstanceOf[T]
+  val bits = gen.cloneType.asInstanceOf[T]
   override def cloneType = new ValidUndirectioned(gen).asInstanceOf[this.type]
 }
 

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -15,7 +15,7 @@ import xiangshan.backend.fu.FunctionUnit
 import xiangshan.backend.issue.IssueQueue
 import xiangshan.backend.regfile.{Regfile, RfWritePort}
 import xiangshan.backend.roq.Roq
-
+import utils.ParallelOR
 
 /** Backend Pipeline:
   * Decode -> Rename -> Dispatch-1 -> Dispatch-2 -> Issue -> Exe
@@ -137,6 +137,7 @@ class Backend(implicit val p: XSConfig) extends XSModule
     x.valid := y.io.out.fire() && y.io.out.bits.redirectValid
   }
   decode.io.brTags <> brq.io.brTags
+  decBuf.io.isWalking := ParallelOR(roq.io.commits.map(c => c.valid && c.bits.isWalk)).asBool() // TODO: opt this
   decBuf.io.redirect <> redirect
   decBuf.io.in <> decode.io.out
 

--- a/src/main/scala/xiangshan/backend/decode/DecodeBuffer.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeBuffer.scala
@@ -7,6 +7,7 @@ import utils._
 
 class DecodeBuffer extends XSModule {
   val io = IO(new Bundle() {
+    val isWalking = Input(Bool())
     val redirect = Flipped(ValidIO(new Redirect))
     val in  = Vec(DecodeWidth, Flipped(DecoupledIO(new CfCtrl)))
     val out = Vec(RenameWidth, DecoupledIO(new CfCtrl))
@@ -44,10 +45,10 @@ class DecodeBuffer extends XSModule {
         Mux(r.ctrl.noSpecExec,
           !ParallelOR(validVec.take(i)).asBool(),
           !ParallelOR(io.out.zip(validVec).take(i).map(x => x._2 && x._1.bits.ctrl.noSpecExec)).asBool()
-        )
+        ) && !io.isWalking
     } else {
       require( i == 0)
-      io.out(i).valid := validVec(i) && !io.redirect.valid
+      io.out(i).valid := validVec(i) && !io.redirect.valid && !io.isWalking
     }
   }
 


### PR DESCRIPTION
By blocking inst at rename (not ibuffer), ipc of microbench test can improve form 0.618 to 0.629