### PR TITLE
utils,LogUtils: reduce the number of GTimer()

### DIFF
--- a/src/main/scala/utils/LogUtils.scala
+++ b/src/main/scala/utils/LogUtils.scala
@@ -22,11 +22,13 @@ object XSLog {
            (prefix: Boolean, cond: Bool, pable: Printable)
            (implicit name: String): Any =
   {
-    val commonInfo = p"[$debugLevel][time=${GTimer()}] $name: "
     val logEnable = WireInit(false.B)
+    val logTimestamp = WireInit(0.U(64.W))
     ExcitingUtils.addSink(logEnable, "DISPLAY_LOG_ENABLE")
+    ExcitingUtils.addSink(logTimestamp, "logTimestamp")
     if(generateLog){
       when (cond && logEnable) {
+        val commonInfo = p"[$debugLevel][time=$logTimestamp] $name: "
         printf((if (prefix) commonInfo else p"") + pable)
         if (debugLevel >= XSLogLevel.ERROR) {
           assert(false.B)

--- a/src/test/scala/top/XSSim.scala
+++ b/src/test/scala/top/XSSim.scala
@@ -101,8 +101,10 @@ class XSSimTop extends Module {
   ExcitingUtils.addSink(trap.instrCnt, "trapInstrCnt")
   io.trap := trap
 
-  val logEnable = (GTimer() >= io.logCtrl.log_begin) && (GTimer() < io.logCtrl.log_end)
+  val timer = GTimer()
+  val logEnable = (timer >= io.logCtrl.log_begin) && (timer < io.logCtrl.log_end)
   ExcitingUtils.addSource(logEnable, "DISPLAY_LOG_ENABLE")
+  ExcitingUtils.addSource(timer, "logTimestamp")
 
   // Check and dispaly all source and sink connections
   ExcitingUtils.checkAndDisplay()


### PR DESCRIPTION
* this helps to recude about 40k lines of code, and improve the host
  time spent from 89s to 93s for running microbench with test input on
  9900k