### PR TITLE
roq: dont update walkPtrExt when brqRedirect.valid in extrawalk

### DIFF
--- a/src/main/scala/xiangshan/backend/roq/Roq.scala
+++ b/src/main/scala/xiangshan/backend/roq/Roq.scala
@@ -237,7 +237,7 @@ class Roq extends XSModule {
   // when redirect, walk back roq entries
   when(io.brqRedirect.valid){
     state := s_walk
-    walkPtrExt := Mux(state === s_walk && !walkFinished, walkPtrExt - CommitWidth.U, enqPtrExt - 1.U + dispatchCnt)
+    walkPtrExt := Mux(state === s_walk && !walkFinished, walkPtrExt - CommitWidth.U, Mux(state === s_extrawalk, walkPtrExt, enqPtrExt - 1.U + dispatchCnt))
     walkTgtExt := io.brqRedirect.bits.roqIdx
     enqPtrExt := io.brqRedirect.bits.roqIdx + 1.U
   }


### PR DESCRIPTION
For nested redirect (redirect.valid when ROB is walking), if ROB is in extrawalk state, walkPtrExt should not be changed.