### PR TITLE
emu: asynchronous reset ram

### DIFF
--- a/src/test/csrc/emu.cpp
+++ b/src/test/csrc/emu.cpp
@@ -81,6 +81,9 @@ Emulator::Emulator(int argc, const char *argv[]):
   srand48(args.seed);
   Verilated::randReset(2);
 
+  // init core
+  reset_ncycles(10);
+
   // init ram
   extern void init_ram(const char *img);
   init_ram(args.image);
@@ -103,9 +106,6 @@ Emulator::Emulator(int argc, const char *argv[]):
 #else
   enable_waveform = false;
 #endif
-
-  // init core
-  reset_ncycles(10);
 
   if (args.snapshot_path != NULL) {
     printf("loading from snapshot `%s`...\n", args.snapshot_path);


### PR DESCRIPTION
We need to asynchronous reset the system when reset is true.
In verilator model, it's done by always resetting the external devices when reset is true.
After the reset signal is released, we call init once for external devices to make sure they are correctly reset.