### PR TITLE
replace $fatal with $finish to avoid verilator abort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ $(SIM_TOP_V): $(SCALA_FILE) $(TEST_FILE)
 	date -R
 	mill XiangShan.test.runMain $(SIMTOP) -X verilog -td $(@D) --full-stacktrace --output-file $(@F) $(SIM_ARGS)
 	sed -i '/module XSSimTop/,/endmodule/d' $(SIM_TOP_V)
-	sed -i -e 's/$$fatal/$$stop/g' $(SIM_TOP_V)
+	sed -i -e 's/$$fatal/$$finish/g' $(SIM_TOP_V)
 	date -R
 
 EMU_TOP      = XSSimSoC

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ $(SIM_TOP_V): $(SCALA_FILE) $(TEST_FILE)
 	date -R
 	mill XiangShan.test.runMain $(SIMTOP) -X verilog -td $(@D) --full-stacktrace --output-file $(@F) $(SIM_ARGS)
 	sed -i '/module XSSimTop/,/endmodule/d' $(SIM_TOP_V)
+	sed -i -e 's/$$fatal/$$stop/g' $(SIM_TOP_V)
 	date -R
 
 EMU_TOP      = XSSimSoC

--- a/src/test/csrc/emu.cpp
+++ b/src/test/csrc/emu.cpp
@@ -243,7 +243,7 @@ uint64_t Emulator::execute(uint64_t max_cycle, uint64_t max_instr) {
   diff.wdata = wdata;
   diff.wdst = wdst;
 
-  while (trapCode == STATE_RUNNING) {
+  while (!Verilated::gotFinish() && trapCode == STATE_RUNNING) {
     if (!(max_cycle > 0 && max_instr > 0 && instr_left_last_cycle >= max_instr /* handle overflow */)) {
       trapCode = STATE_LIMIT_EXCEEDED;
       break;
@@ -318,6 +318,11 @@ uint64_t Emulator::execute(uint64_t max_cycle, uint64_t max_instr) {
       }
     }
 #endif
+  }
+
+  if (Verilated::gotFinish()) {
+    eprintf("The simulation stopped. There might be some assertion failed.\n");
+    trapCode = STATE_ABORT;
   }
 
 #if VM_TRACE == 1


### PR DESCRIPTION
This pull request replaces $fatal with $finish in the verilog file to avoid verilator abort on assertions.

By replacing $fatal with $finish, the simulation framework takes control of the simulation when assertion failed. 