### PR TITLE
SoC: move l2cache to SoC

### DIFF
--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -259,40 +259,11 @@ object AddressSpace extends HasXSParameter {
 
 class XSCore()(implicit p: config.Parameters) extends LazyModule with HasXSParameter {
 
-  // inner nodes
+  // outer facing nodes
   val dcache = LazyModule(new DCache())
   val uncache = LazyModule(new Uncache())
   val l1pluscache = LazyModule(new L1plusCache())
   val ptw = LazyModule(new PTW())
-
-  // out facing nodes
-  val mem = TLIdentityNode()
-  val mmio = uncache.clientNode
-
-  // L1 to L2 network
-  // -------------------------------------------------
-  private val l2_xbar = TLXbar()
-
-  private val l2 = LazyModule(new InclusiveCache(
-    CacheParameters(
-      level = 2,
-      ways = L2NWays,
-      sets = L2NSets,
-      blockBytes = L2BlockSize,
-      beatBytes = L1BusWidth / 8, // beatBytes = l1BusDataWidth / 8
-      cacheName = s"L2"
-    ),
-    InclusiveCacheMicroParameters(
-      writeBytes = 8
-    )
-  ))
-
-  l2_xbar := TLBuffer() := DebugIdentityNode() := dcache.clientNode
-  l2_xbar := TLBuffer() := DebugIdentityNode() := l1pluscache.clientNode
-  l2_xbar := TLBuffer() := DebugIdentityNode() := ptw.node
-  l2.node := TLBuffer() := DebugIdentityNode() := l2_xbar
-
-  mem := l2.node
 
   lazy val module = new XSCoreImp(this)
 }


### PR DESCRIPTION
This pull request moves L2 cache out of XSCore. L2 cache should be in SoC system-level. 