### PR TITLE
change emu exit code

### DIFF
--- a/src/test/csrc/emu.h
+++ b/src/test/csrc/emu.h
@@ -40,9 +40,9 @@ class Emulator {
 
   enum {
     STATE_GOODTRAP = 0,
-    STATE_BADTRAP,
-    STATE_ABORT,
-    STATE_LIMIT_EXCEEDED,
+    STATE_BADTRAP = 1,
+    STATE_ABORT = 2,
+    STATE_LIMIT_EXCEEDED = 3,
     STATE_RUNNING = -1
   };
 
@@ -74,4 +74,5 @@ public:
   uint64_t get_cycles() const { return cycles; }
   EmuArgs get_args() const { return args; }
   bool is_good_trap() { return trapCode == STATE_GOODTRAP; };
+  int get_trapcode() { return trapCode; }
 };

--- a/src/test/csrc/main.cpp
+++ b/src/test/csrc/main.cpp
@@ -21,6 +21,7 @@ int main(int argc, const char** argv) {
   auto args = emu->get_args();
   uint64_t cycles = emu->execute(args.max_cycles, args.max_instr);
   bool is_good_trap = emu->is_good_trap();
+  int trap_code = emu->get_trapcode();
   delete emu;
 
   extern uint32_t uptime(void);
@@ -30,5 +31,6 @@ int main(int argc, const char** argv) {
       " (this will be different from cycleCnt if emu loads a snapshot)\n" ANSI_COLOR_RESET, args.seed, cycles);
   eprintf(ANSI_COLOR_BLUE "Host time spent: %dms\n" ANSI_COLOR_RESET, ms);
 
-  return !is_good_trap;
+  // return !is_good_trap;
+  return trap_code;
 }


### PR DESCRIPTION
修改了 `src/test/csrc/main.cpp` 的返回值，使它返回 `trapcode`。  
修改动机在这里：[an-issue](https://github.com/RISCVERS/XiangShan/issues/337)  