### PR TITLE
Roq: wrap data, deqPtr, enqPtr into separate modules

### DIFF
--- a/src/main/scala/utils/DataModuleTemplate.scala
+++ b/src/main/scala/utils/DataModuleTemplate.scala
@@ -3,7 +3,7 @@ package utils
 import chisel3._
 import chisel3.util._
 
-class DataModuleTemplate[T <: Data](gen: T, numEntries: Int, numRead: Int, numWrite: Int) extends Module {
+class DataModuleTemplate[T <: Data](gen: T, numEntries: Int, numRead: Int, numWrite: Int, useBitVec: Boolean = false) extends Module {
   val io = IO(new Bundle {
     val raddr = Vec(numRead,  Input(UInt(log2Up(numEntries).W)))
     val rdata = Vec(numRead,  Output(gen))
@@ -19,30 +19,39 @@ class DataModuleTemplate[T <: Data](gen: T, numEntries: Int, numRead: Int, numWr
     io.rdata(i) := data(io.raddr(i))
   }
 
-  // write ports
-  // val waddr_dec = VecInit(io.waddr.map(addr => UIntToOH(addr)(numEntries - 1, 0)))
-  // val waddr_dec_with_en = VecInit(io.wen.zip(waddr_dec).map{case (en, addr) => Fill(numEntries, en) & addr})
+  if (useBitVec) {
+    // waddr_dec(i)(j): waddr(i) is target at entry(j)
+    val waddr_dec = VecInit(io.waddr.map(UIntToOH(_)(numEntries - 1, 0)))
+    // waddr_dec_with_en(i)(j): entry(j) is written by io.wdata(i)
+    val waddr_dec_with_en = VecInit(io.wen.zip(waddr_dec).map{case (en, addr) => Fill(numEntries, en) & addr})
 
-  // val wen_dec = VecInit((0 until numEntries).map(i => Cat(waddr_dec_with_en.map(en => en(i))).orR))
-  // val wdata_dec = VecInit((0 until numEntries).map(i => waddr_dec_with_en.zip(io.wdata).map{ case (en, data) =>
-  //   Fill(gen.getWidth, en) & data.asUInt
-  // }.reduce(_ | _).asTypeOf(gen)))
+    val wen_dec = VecInit((0 until numEntries).map(j => {
+      val data_wen = VecInit(waddr_dec_with_en.map(en => en(j)))
+      data_wen.suggestName(s"data_wen_$j")
+      data_wen.asUInt.orR
+    }))
+    val wdata_dec = VecInit((0 until numEntries).map(j =>
+      waddr_dec_with_en.zip(io.wdata).map{ case (en, data) => Fill(gen.getWidth, en(j)) & data.asUInt}.reduce(_ | _).asTypeOf(gen)
+    ))
 
-  // waddr_dec.suggestName("waddr_dec")
-  // waddr_dec_with_en.suggestName("waddr_dec_with_en")
-  // wen_dec.suggestName("wen_dec")
-  // wdata_dec.suggestName("wdata_dec")
+    waddr_dec.suggestName("waddr_dec")
+    waddr_dec_with_en.suggestName("waddr_dec_with_en")
+    wen_dec.suggestName("wen_dec")
+    wdata_dec.suggestName("wdata_dec")
 
-  // for (i <- 0 until numEntries) {
-  //   when (wen_dec(i)) {
-  //     data(i) := wdata_dec(i)
-  //   }
-  // }
-
-  // below is the write ports with priorities
-  for (i <- 0 until numWrite) {
-    when (io.wen(i)) {
-      data(io.waddr(i)) := io.wdata(i)
+    // write ports
+    for (i <- 0 until numEntries) {
+      when (wen_dec(i)) {
+        data(i) := wdata_dec(i)
+      }
+    }
+  }
+  else {
+    // below is the write ports (with priorities)
+    for (i <- 0 until numWrite) {
+      when (io.wen(i)) {
+        data(io.waddr(i)) := io.wdata(i)
+      }
     }
   }
 

--- a/src/main/scala/utils/DataModuleTemplate.scala
+++ b/src/main/scala/utils/DataModuleTemplate.scala
@@ -1,0 +1,55 @@
+package utils
+
+import chisel3._
+import chisel3.util._
+
+class DataModuleTemplate[T <: Data](gen: T, numEntries: Int, numRead: Int, numWrite: Int) extends Module {
+  val io = IO(new Bundle {
+    val raddr = Vec(numRead,  Input(UInt(log2Up(numEntries).W)))
+    val rdata = Vec(numRead,  Output(gen))
+    val wen   = Vec(numWrite, Input(Bool()))
+    val waddr = Vec(numWrite, Input(UInt(log2Up(numEntries).W)))
+    val wdata = Vec(numWrite, Input(gen))
+  })
+
+  val data = Mem(numEntries, gen)
+
+  // read ports
+  for (i <- 0 until numRead) {
+    io.rdata(i) := data(io.raddr(i))
+  }
+
+  // write ports
+  // val waddr_dec = VecInit(io.waddr.map(addr => UIntToOH(addr)(numEntries - 1, 0)))
+  // val waddr_dec_with_en = VecInit(io.wen.zip(waddr_dec).map{case (en, addr) => Fill(numEntries, en) & addr})
+
+  // val wen_dec = VecInit((0 until numEntries).map(i => Cat(waddr_dec_with_en.map(en => en(i))).orR))
+  // val wdata_dec = VecInit((0 until numEntries).map(i => waddr_dec_with_en.zip(io.wdata).map{ case (en, data) =>
+  //   Fill(gen.getWidth, en) & data.asUInt
+  // }.reduce(_ | _).asTypeOf(gen)))
+
+  // waddr_dec.suggestName("waddr_dec")
+  // waddr_dec_with_en.suggestName("waddr_dec_with_en")
+  // wen_dec.suggestName("wen_dec")
+  // wdata_dec.suggestName("wdata_dec")
+
+  // for (i <- 0 until numEntries) {
+  //   when (wen_dec(i)) {
+  //     data(i) := wdata_dec(i)
+  //   }
+  // }
+
+  // below is the write ports with priorities
+  for (i <- 0 until numWrite) {
+    when (io.wen(i)) {
+      data(io.waddr(i)) := io.wdata(i)
+    }
+  }
+
+  // DataModuleTemplate should not be used when there're any write conflicts
+  for (i <- 0 until numWrite) {
+    for (j <- i+1 until numWrite) {
+      assert(!(io.wen(i) && io.wen(j) && io.waddr(i) === io.waddr(j)))
+    }
+  }
+}

--- a/src/main/scala/xiangshan/backend/roq/Roq.scala
+++ b/src/main/scala/xiangshan/backend/roq/Roq.scala
@@ -7,6 +7,8 @@ import xiangshan._
 import utils._
 import xiangshan.backend.LSUOpType
 import xiangshan.backend.fu.fpu.Fflags
+import xiangshan.mem.{LqPtr, SqPtr}
+
 object roqDebugId extends Function0[Integer] {
   var x = 0
   def apply(): Integer = {
@@ -48,24 +50,28 @@ class RoqEnqIO extends XSBundle {
   val resp = Vec(RenameWidth, Output(new RoqPtr))
 }
 
-class RoqDataModule(numRead: Int, numWrite: Int) extends XSModule {
-  val io = IO(new Bundle {
-    val raddr = Vec(numRead, Input(new RoqPtr))
-    val rdata = Vec(numRead, Output(new RoqCommitInfo))
-    val wen = Vec(numWrite, Input(Bool()))
-    val waddr = Vec(numWrite, Input(new RoqPtr))
-    val wdata = Vec(numWrite, Input(new RoqCommitInfo))
-  })
+class RoqDispatchData extends XSBundle {
+  // commit info
+  val ldest = UInt(5.W)
+  val rfWen = Bool()
+  val fpWen = Bool()
+  val commitType = CommitType()
+  val pdest = UInt(PhyRegIdxWidth.W)
+  val old_pdest = UInt(PhyRegIdxWidth.W)
+  val lqIdx = new LqPtr
+  val sqIdx = new SqPtr
 
-  val data = Mem(RoqSize, new RoqCommitInfo)
-  for (i <- 0 until numRead) {
-    io.rdata(i) := data(io.raddr(i).value)
-  }
-  for (i <- 0 until numWrite) {
-    when (io.wen(i)) {
-      data(io.waddr(i).value) := io.wdata(i)
-    }
-  }
+  // exception info
+  val pc = UInt(VAddrBits.W)
+  val crossPageIPFFix = Bool()
+  val exceptionVec = Vec(16, Bool())
+}
+
+class RoqWbData extends XSBundle {
+  // mostly for exceptions
+  val exceptionVec = Vec(16, Bool())
+  val fflags = new Fflags
+  val flushPipe = Bool()
 }
 
 class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
@@ -84,34 +90,19 @@ class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
 
   // instvalid field
   val valid = RegInit(VecInit(List.fill(RoqSize)(false.B)))
-
-  // status
+  // writeback status
   val writebacked = Reg(Vec(RoqSize, Bool()))
-
   // data for redirect, exception, etc.
   val flagBkup = RegInit(VecInit(List.fill(RoqSize)(false.B)))
-  val exuFflags = Mem(RoqSize, new Fflags)
-
-  // uop field used when commit
-  // flushPipe (wb) (commit) (used in roq)
-  // lidx (wb) (commit)
-  // sidx (wb) (commit)
-  // uop.ctrl.commitType (wb) (commit) (L/S)
-  // exceptionVec (wb) (commit)
-  // roqIdx (dispatch) (commit)
-  // crossPageIPFFix (dispatch) (commit)
-
-  // uop field used when walk
-  // ctrl.fpWen (dispatch) (walk)
-  // ctrl.rfWen (dispatch) (walk)
-  // ldest (dispatch) (walk)
 
   // data for debug
-  val microOp = Mem(RoqSize, new MicroOp)
+  // Warn: debug_* prefix should not exist in generated verilog.
+  val debug_microOp = Mem(RoqSize, new MicroOp)
   val debug_exuData = Reg(Vec(RoqSize, UInt(XLEN.W)))//for debug
   val debug_exuDebug = Reg(Vec(RoqSize, new DebugBundle))//for debug
 
-  // ptr
+  // pointers
+  // For enqueue ptr, we don't duplicate it since only enqueue needs it.
   val enqPtr = RegInit(0.U.asTypeOf(new RoqPtr))
   val deqPtrVec = RegInit(VecInit((0 until CommitWidth).map(_.U.asTypeOf(new RoqPtr))))
   val walkPtrVec = Reg(Vec(CommitWidth, new RoqPtr))
@@ -124,40 +115,49 @@ class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
 
   val isEmpty = enqPtr === deqPtr
 
+  /**
+    * states of Roq
+    */
   val s_idle :: s_walk :: s_extrawalk :: Nil = Enum(3)
   val state = RegInit(s_idle)
 
-  io.roqDeqPtr := deqPtr
-
-  // For enqueue ptr, we don't duplicate it since only enqueue needs it.
-
-
   /**
-    * CommitDataModule: store commit info separately
-    * (1) read: commits/walk
+    * Data Modules
+    *
+    * CommitDataModule: data from dispatch
+    * (1) read: commits/walk/exception
     * (2) write: enqueue
+    *
+    * WritebackData: data from writeback
+    * (1) read: commits/walk/exception
+    * (2) write: write back from exe units
     */
-  val commitData = Module(new RoqDataModule(CommitWidth, RenameWidth))
-  val deqCommitData = commitData.io.rdata(0)
-  for (i <- 0 until RenameWidth) {
-    commitData.io.wen(i) := false.B
-    commitData.io.waddr(i) := enqPtrVec(i)
-    commitData.io.wdata(i).ldest := io.enq.req(i).bits.ctrl.ldest
-    commitData.io.wdata(i).rfWen := io.enq.req(i).bits.ctrl.rfWen
-    commitData.io.wdata(i).fpWen := io.enq.req(i).bits.ctrl.fpWen
-    commitData.io.wdata(i).commitType := io.enq.req(i).bits.ctrl.commitType
-    commitData.io.wdata(i).pdest := io.enq.req(i).bits.pdest
-    commitData.io.wdata(i).old_pdest := io.enq.req(i).bits.old_pdest
-    commitData.io.wdata(i).lqIdx := io.enq.req(i).bits.lqIdx
-    commitData.io.wdata(i).sqIdx := io.enq.req(i).bits.sqIdx
-    commitData.io.wdata(i).pc := io.enq.req(i).bits.cf.pc
+  val dispatchData = Module(new DataModuleTemplate(new RoqDispatchData, RoqSize, CommitWidth, RenameWidth))
+  val writebackData = Module(new DataModuleTemplate(new RoqWbData, RoqSize, CommitWidth, numWbPorts))
+  def mergeExceptionVec(dpData: RoqDispatchData, wbData: RoqWbData) = {
+    // these exceptions can be determined before dispatch.
+    // by default, let all exceptions be determined by dispatch.
+    // mergeVec(instrAddrMisaligned) := dpData(instrAddrMisaligned)
+    // mergeVec(instrAccessFault) := dpData(instrAccessFault)
+    // mergeVec(illegalInstr) := dpData(illegalInstr)
+    // mergeVec(instrPageFault) := dpData(instrPageFault)
+    val mergeVec = WireInit(dpData.exceptionVec)
+    // these exceptions are determined in execution units
+    mergeVec(breakPoint) := wbData.exceptionVec(breakPoint)
+    mergeVec(loadAddrMisaligned) := wbData.exceptionVec(loadAddrMisaligned)
+    mergeVec(loadAccessFault) := wbData.exceptionVec(loadAccessFault)
+    mergeVec(storeAddrMisaligned) := wbData.exceptionVec(storeAddrMisaligned)
+    mergeVec(storeAccessFault) := wbData.exceptionVec(storeAccessFault)
+    mergeVec(ecallU) := wbData.exceptionVec(ecallU)
+    mergeVec(ecallS) := wbData.exceptionVec(ecallS)
+    mergeVec(ecallM) := wbData.exceptionVec(ecallM)
+    mergeVec(loadPageFault) := wbData.exceptionVec(loadPageFault)
+    mergeVec(storePageFault) := wbData.exceptionVec(storePageFault)
+    // returns the merged exception vector
+    mergeVec
   }
-  for (i <- 0 until CommitWidth) {
-    commitData.io.raddr(i) := walkPtrVec(i)
-    when (state === s_idle) {
-      commitData.io.raddr(i) := deqPtrVec(i)
-    }
-  }
+
+  io.roqDeqPtr := deqPtr
 
   /**
     * Enqueue (from dispatch)
@@ -172,231 +172,228 @@ class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
   // When any instruction commits, hasNoSpecExec should be set to false.B
   when (io.commits.valid.asUInt.orR) { hasNoSpecExec:= false.B }
 
+  io.enq.canAccept := allowEnqueue && !hasBlockBackward
+  io.enq.isEmpty   := isEmpty
+  io.enq.resp := enqPtrVec
+  val canEnqueue = VecInit(io.enq.req.map(_.valid && io.enq.canAccept))
   for (i <- 0 until RenameWidth) {
-    // we don't determine whether io.redirect.valid here since redirect has higher priority
-    when(io.enq.req(i).valid && io.enq.canAccept) {
-      // store uop in data module and microOp Vec
-      commitData.io.wen(i) := true.B
-      microOp(enqPtrVec(i).value) := io.enq.req(i).bits
-      when(io.enq.req(i).bits.ctrl.blockBackward) {
+    // we don't check whether io.redirect is valid here since redirect has higher priority
+    when (canEnqueue(i)) {
+      // store uop in data module and debug_microOp Vec
+      debug_microOp(enqPtrVec(i).value) := io.enq.req(i).bits
+      when (io.enq.req(i).bits.ctrl.blockBackward) {
         hasBlockBackward := true.B
       }
-      when(io.enq.req(i).bits.ctrl.noSpecExec) {
+      when (io.enq.req(i).bits.ctrl.noSpecExec) {
         hasNoSpecExec := true.B
       }
     }
-    io.enq.resp(i) := enqPtrVec(i)
   }
-
-  val firedDispatch = Mux(io.enq.canAccept, PopCount(Cat(io.enq.req.map(_.valid))), 0.U)
-  io.enq.canAccept := allowEnqueue && !hasBlockBackward
-  io.enq.isEmpty   := isEmpty
+  // debug info for enqueue (dispatch)
+  val dispatchNum = Mux(io.enq.canAccept, PopCount(Cat(io.enq.req.map(_.valid))), 0.U)
   XSDebug(p"(ready, valid): ${io.enq.canAccept}, ${Binary(Cat(io.enq.req.map(_.valid)))}\n")
-  when (firedDispatch =/= 0.U) {
-    XSInfo("dispatched %d insts\n", firedDispatch)
-  }
+  XSInfo(dispatchNum =/= 0.U, p"dispatched $dispatchNum insts\n")
+
 
   /**
     * Writeback (from execution units)
     */
-  val firedWriteback = io.exeWbResults.map(_.fire())
-  XSInfo(PopCount(firedWriteback) > 0.U, "writebacked %d insts\n", PopCount(firedWriteback))
-  for(i <- 0 until numWbPorts) {
-    when(io.exeWbResults(i).fire()){
-      val wbIdxExt = io.exeWbResults(i).bits.uop.roqIdx
-      val wbIdx = wbIdxExt.value
-      microOp(wbIdx).cf.exceptionVec := io.exeWbResults(i).bits.uop.cf.exceptionVec
-      microOp(wbIdx).ctrl.flushPipe := io.exeWbResults(i).bits.uop.ctrl.flushPipe
-      microOp(wbIdx).diffTestDebugLrScValid := io.exeWbResults(i).bits.uop.diffTestDebugLrScValid
+  for (i <- 0 until numWbPorts) {
+    when (io.exeWbResults(i).valid) {
+      val wbIdx = io.exeWbResults(i).bits.uop.roqIdx.value
+      debug_microOp(wbIdx).cf.exceptionVec := io.exeWbResults(i).bits.uop.cf.exceptionVec
+      debug_microOp(wbIdx).ctrl.flushPipe := io.exeWbResults(i).bits.uop.ctrl.flushPipe
+      debug_microOp(wbIdx).diffTestDebugLrScValid := io.exeWbResults(i).bits.uop.diffTestDebugLrScValid
       debug_exuData(wbIdx) := io.exeWbResults(i).bits.data
       debug_exuDebug(wbIdx) := io.exeWbResults(i).bits.debug
 
-      val debug_Uop = microOp(wbIdx)
+      val debug_Uop = debug_microOp(wbIdx)
       XSInfo(true.B,
         p"writebacked pc 0x${Hexadecimal(debug_Uop.cf.pc)} wen ${debug_Uop.ctrl.rfWen} " +
         p"data 0x${Hexadecimal(io.exeWbResults(i).bits.data)} ldst ${debug_Uop.ctrl.ldest} pdst ${debug_Uop.pdest} " +
-        p"skip ${io.exeWbResults(i).bits.debug.isMMIO} roqIdx: ${wbIdxExt}\n"
+        p"skip ${io.exeWbResults(i).bits.debug.isMMIO} roqIdx: ${io.exeWbResults(i).bits.uop.roqIdx}\n"
       )
     }
   }
+  val writebackNum = PopCount(io.exeWbResults.map(_.valid))
+  XSInfo(writebackNum =/= 0.U, "writebacked %d insts\n", writebackNum)
+
 
   /**
-    * Interrupt and Exceptions
+    * RedirectOut: Interrupt and Exceptions
     */
-  val deqUop = microOp(deqPtr.value)
+  val deqDispatchData = dispatchData.io.rdata(0)
+  val deqWritebackData = writebackData.io.rdata(0)
+  val debug_deqUop = debug_microOp(deqPtr.value)
+
   val deqPtrWritebacked = writebacked(deqPtr.value) && valid(deqPtr.value)
-  val intrEnable = io.csr.intrBitSet && !isEmpty && !hasNoSpecExec &&
-    deqCommitData.commitType =/= CommitType.STORE && deqCommitData.commitType =/= CommitType.LOAD
-  val exceptionEnable = deqPtrWritebacked && Cat(deqUop.cf.exceptionVec).orR()
-  val isFlushPipe = deqPtrWritebacked && deqUop.ctrl.flushPipe
+  val deqExceptionVec = mergeExceptionVec(deqDispatchData, deqWritebackData)
+  // For MMIO instructions, they should not trigger interrupts since they may be sent to lower level before it writes back.
+  // However, we cannot determine whether a load/store instruction is MMIO.
+  // Thus, we don't allow load/store instructions to trigger an interrupt.
+  val intrEnable = io.csr.intrBitSet && !isEmpty && !hasNoSpecExec && !CommitType.isLoadStore(deqDispatchData.commitType)
+  val exceptionEnable = deqPtrWritebacked && Cat(deqExceptionVec).orR()
+  val isFlushPipe = deqPtrWritebacked && deqWritebackData.flushPipe
   io.redirectOut := DontCare
   io.redirectOut.valid := (state === s_idle) && (intrEnable || exceptionEnable || isFlushPipe)
   io.redirectOut.bits.level := Mux(isFlushPipe, RedirectLevel.flushAll, RedirectLevel.exception)
   io.redirectOut.bits.interrupt := intrEnable
-  io.redirectOut.bits.target := Mux(isFlushPipe, deqCommitData.pc + 4.U, io.csr.trapTarget)
-  io.exception := deqUop
-  io.exception.ctrl.commitType := deqCommitData.commitType
-  io.exception.lqIdx := deqCommitData.lqIdx
-  io.exception.sqIdx := deqCommitData.sqIdx
-  io.exception.cf.pc := deqCommitData.pc
+  io.redirectOut.bits.target := Mux(isFlushPipe, deqDispatchData.pc + 4.U, io.csr.trapTarget)
+
+  io.exception := debug_deqUop
+  io.exception.ctrl.commitType := deqDispatchData.commitType
+  io.exception.lqIdx := deqDispatchData.lqIdx
+  io.exception.sqIdx := deqDispatchData.sqIdx
+  io.exception.cf.pc := deqDispatchData.pc
+  io.exception.cf.exceptionVec := deqExceptionVec
+  io.exception.cf.crossPageIPFFix := deqDispatchData.crossPageIPFFix
+
   XSDebug(io.redirectOut.valid,
-    "generate redirect: pc 0x%x intr %d excp %d flushpp %d target:0x%x Traptarget 0x%x exceptionVec %b\n",
-    io.exception.cf.pc, intrEnable, exceptionEnable, isFlushPipe, io.redirectOut.bits.target, io.csr.trapTarget,
-    Cat(microOp(deqPtr.value).cf.exceptionVec))
+    p"generate redirect: pc 0x${Hexadecimal(io.exception.cf.pc)} intr $intrEnable " +
+    p"excp $exceptionEnable flushPipe $isFlushPipe target 0x${Hexadecimal(io.redirectOut.bits.target)} " +
+    p"Trap_target 0x${Hexadecimal(io.csr.trapTarget)} exceptionVec ${Binary(deqExceptionVec.asUInt)}\n")
+
 
   /**
     * Commits (and walk)
     * They share the same width.
     */
   val walkCounter = Reg(UInt(log2Up(RoqSize).W))
-  val shouldWalkVec = Wire(Vec(CommitWidth, Bool()))
-  for(i <- shouldWalkVec.indices){
-    shouldWalkVec(i) := i.U < walkCounter
-  }
+  val shouldWalkVec = VecInit((0 until CommitWidth).map(_.U < walkCounter))
   val walkFinished = walkCounter <= CommitWidth.U
 
-  // extra space is used weh roq has no enough space, but mispredict recovery needs such info to walk regmap
-  val needExtraSpaceForMPR = WireInit(VecInit(
-    List.tabulate(RenameWidth)(i => io.redirect.valid && io.enq.needAlloc(i))
-  ))
+  // extra space is used when roq has no enough space, but mispredict recovery needs such info to walk regmap
+  val needExtraSpaceForMPR = VecInit((0 until CommitWidth).map(i => io.redirect.valid && io.enq.needAlloc(i)))
   val extraSpaceForMPR = Reg(Vec(RenameWidth, new RoqCommitInfo))
   val usedSpaceForMPR = Reg(Vec(RenameWidth, Bool()))
 
-  val storeCommitVec = WireInit(VecInit(Seq.fill(CommitWidth)(false.B)))
-  val cfiCommitVec = WireInit(VecInit(Seq.fill(CommitWidth)(false.B)))
   // wiring to csr
   val fflags = WireInit(0.U.asTypeOf(new Fflags))
-  val dirty_fs = WireInit(false.B)
+  val dirty_fs = Mux(io.commits.isWalk, false.B, Cat(io.commits.valid.zip(io.commits.info.map(_.fpWen)).map{case (v, w) => v & w}).orR)
 
   io.commits.isWalk := state =/= s_idle
+  val commit_v = Mux(state === s_idle, VecInit(deqPtrVec.map(ptr => valid(ptr.value))), VecInit(walkPtrVec.map(ptr => valid(ptr.value))))
+  val commit_w = VecInit(deqPtrVec.map(ptr => writebacked(ptr.value)))
+  val commit_exception = dispatchData.io.rdata.zip(writebackData.io.rdata).map{ case (d, w) => mergeExceptionVec(d, w).asUInt.orR }
+  val commit_block = VecInit((0 until CommitWidth).map(i => !commit_w(i) || commit_exception(i) || writebackData.io.rdata(i).flushPipe))
   for (i <- 0 until CommitWidth) {
-    io.commits.valid(i) := false.B
-    val commitInfo = commitData.io.rdata(i)
-    io.commits.info(i) := commitInfo
-    switch (state) {
-      is (s_idle) {
-        val commitIdx = deqPtrVec(i).value
-        val commitUop = microOp(commitIdx)
+    // defaults: state === s_idle and instructions commit
+    val isBlocked = if (i != 0) Cat(commit_block.take(i)).orR || intrEnable else false.B
+    io.commits.valid(i) := commit_v(i) && commit_w(i) && !isBlocked && !commit_exception(i)
+    io.commits.info(i)  := dispatchData.io.rdata(i)
 
-        val hasException = Cat(commitUop.cf.exceptionVec).orR() || intrEnable
-        val canCommit = if(i!=0) (io.commits.valid(i-1) && !microOp(deqPtrVec(i-1).value).ctrl.flushPipe) else true.B
-        val v = valid(commitIdx)
-        val w = writebacked(commitIdx)
-        io.commits.valid(i) := v && w && canCommit && !hasException
-        storeCommitVec(i) := io.commits.valid(i) && CommitType.isLoadStore(commitInfo.commitType) && CommitType.lsInstIsStore(commitInfo.commitType)
-        cfiCommitVec(i) := io.commits.valid(i) && CommitType.isBranch(commitInfo.commitType)
-
-        val commitFflags = exuFflags(commitIdx)
-        when(io.commits.valid(i)){
-          when(commitFflags.asUInt.orR()){
-            // update fflags
-            fflags := exuFflags(commitIdx)
-          }
-          when(commitInfo.fpWen){
-            // set fs to dirty
-            dirty_fs := true.B
-          }
-        }
-
-        XSInfo(io.commits.valid(i),
-          "retired pc %x wen %d ldest %d pdest %x old_pdest %x data %x fflags: %b\n",
-          commitUop.cf.pc,
-          commitInfo.rfWen,
-          commitInfo.ldest,
-          commitInfo.pdest,
-          commitInfo.old_pdest,
-          debug_exuData(commitIdx),
-          exuFflags(commitIdx).asUInt
-        )
-      }
-
-      is (s_walk) {
-        val idx = walkPtrVec(i).value
-        val v = valid(idx)
-        val walkUop = microOp(idx)
-        io.commits.valid(i) := v && shouldWalkVec(i)
-        when (shouldWalkVec(i)) {
-          v := false.B
-        }
-        XSInfo(io.commits.valid(i) && shouldWalkVec(i), "walked pc %x wen %d ldst %d data %x\n",
-          walkUop.cf.pc,
-          commitInfo.rfWen,
-          commitInfo.ldest,
-          debug_exuData(idx)
-        )
-      }
-
-      is (s_extrawalk) {
-        val idx = RenameWidth-i-1
-        val walkUop = extraSpaceForMPR(idx)
-        io.commits.valid(i) := usedSpaceForMPR(idx)
-        io.commits.info(i) := walkUop
-        state := s_walk
-        XSInfo(io.commits.valid(i), "use extra space walked wen %d ldst %d\n",
-          // walkUop.cf.pc,
-          commitInfo.rfWen,
-          commitInfo.ldest
-        )
+    when (state === s_idle) {
+      when (io.commits.valid(i) && writebackData.io.rdata(i).fflags.asUInt.orR()) {
+        fflags := writebackData.io.rdata(i).fflags
       }
     }
+
+    when (state === s_walk) {
+      io.commits.valid(i) := commit_v(i) && shouldWalkVec(i)
+    }.elsewhen(state === s_extrawalk) {
+      io.commits.valid(i) := usedSpaceForMPR(RenameWidth-i-1)
+      io.commits.info(i)  := extraSpaceForMPR(RenameWidth-i-1)
+      state := s_walk
+    }
+
+    XSInfo(state === s_idle && io.commits.valid(i),
+      "retired pc %x wen %d ldest %d pdest %x old_pdest %x data %x fflags: %b\n",
+      debug_microOp(deqPtrVec(i).value).cf.pc,
+      io.commits.info(i).rfWen,
+      io.commits.info(i).ldest,
+      io.commits.info(i).pdest,
+      io.commits.info(i).old_pdest,
+      debug_exuData(deqPtrVec(i).value),
+      writebackData.io.rdata(i).fflags.asUInt
+    )
+    XSInfo(state === s_walk && io.commits.valid(i), "walked pc %x wen %d ldst %d data %x\n",
+      debug_microOp(walkPtrVec(i).value).cf.pc,
+      io.commits.info(i).rfWen,
+      io.commits.info(i).ldest,
+      debug_exuData(walkPtrVec(i).value)
+    )
+    XSInfo(state === s_extrawalk && io.commits.valid(i), "use extra space walked wen %d ldst %d\n",
+      io.commits.info(i).rfWen,
+      io.commits.info(i).ldest
+    )
   }
 
   io.csr.fflags := fflags
   io.csr.dirty_fs := dirty_fs
-
-  val validCommit = io.commits.valid
-  val commitCnt = PopCount(validCommit)
-  when(state===s_walk) {
-    //exit walk state when all roq entry is commited
-    when(walkFinished) {
-      state := s_idle
-    }
-    for (i <- 0 until CommitWidth) {
-      walkPtrVec(i) := walkPtrVec(i) - CommitWidth.U
-    }
-    walkCounter := walkCounter - commitCnt
-    XSInfo(p"rolling back: $enqPtr $deqPtr walk $walkPtr walkcnt $walkCounter\n")
-  }
-
-  // move tail ptr
-  val retireCounter = Mux(state === s_idle, commitCnt, 0.U)
-  XSInfo(retireCounter > 0.U, "retired %d insts\n", retireCounter)
-
   // commit branch to brq
-  io.bcommit := PopCount(cfiCommitVec)
+  val cfiCommitVec = VecInit(io.commits.valid.zip(io.commits.info.map(_.commitType)).map{case(v, t) => v && CommitType.isBranch(t)})
+  io.bcommit := Mux(io.commits.isWalk, 0.U, PopCount(cfiCommitVec))
 
+
+  /**
+    * read and write of data modules
+    */
+  val commitReadAddr = Mux(state === s_idle, VecInit(deqPtrVec.map(_.value)), VecInit(walkPtrVec.map(_.value)))
+  dispatchData.io.wen := canEnqueue
+  dispatchData.io.waddr := enqPtrVec.map(_.value)
+  dispatchData.io.wdata.zip(io.enq.req.map(_.bits)).map{ case (wdata, req) =>
+    wdata.ldest := req.ctrl.ldest
+    wdata.rfWen := req.ctrl.rfWen
+    wdata.fpWen := req.ctrl.fpWen
+    wdata.commitType := req.ctrl.commitType
+    wdata.pdest := req.pdest
+    wdata.old_pdest := req.old_pdest
+    wdata.lqIdx := req.lqIdx
+    wdata.sqIdx := req.sqIdx
+    wdata.pc := req.cf.pc
+    wdata.crossPageIPFFix := req.cf.crossPageIPFFix
+    wdata.exceptionVec := req.cf.exceptionVec
+  }
+  dispatchData.io.raddr := commitReadAddr
+
+  writebackData.io.wen := io.exeWbResults.map(_.valid)
+  writebackData.io.waddr := io.exeWbResults.map(_.bits.uop.roqIdx.value)
+  writebackData.io.wdata.zip(io.exeWbResults.map(_.bits)).map{ case (wdata, wb) =>
+    wdata.exceptionVec := wb.uop.cf.exceptionVec
+    wdata.fflags := wb.fflags
+    wdata.flushPipe := wb.uop.ctrl.flushPipe
+  }
+  writebackData.io.raddr := commitReadAddr
+
+
+
+  /**
+    * state changes
+    * (1) redirect: from s_valid to s_walk or s_extrawalk (depends on whether there're pending instructions in dispatch1)
+    * (2) s_extrawalk to s_walk
+    * (3) s_walk to s_idle: end of walking
+    */
+  //exit walk state when all roq entry is commited
+  when (state === s_walk && walkFinished) {
+    state := s_idle
+  }
   // when redirect, walk back roq entries
   when (io.redirect.valid) {
     state := s_walk
-    for (i <- 0 until CommitWidth) {
-      walkPtrVec(i) := Mux(state === s_walk,
-        walkPtrVec(i) - Mux(walkFinished, walkCounter, CommitWidth.U),
-        Mux(state === s_extrawalk, walkPtrVec(i), enqPtr - (i+1).U))
-    }
-    val currentWalkPtr = Mux(state === s_walk || state === s_extrawalk, walkPtr, enqPtr - 1.U)
-    walkCounter := distanceBetween(currentWalkPtr, io.redirect.bits.roqIdx) + io.redirect.bits.flushItself() - Mux(state === s_walk, commitCnt, 0.U)
   }
-
   // no enough space for walk, allocate extra space
   when (needExtraSpaceForMPR.asUInt.orR && io.redirect.valid) {
     usedSpaceForMPR := needExtraSpaceForMPR
-    (0 until RenameWidth).foreach(i => extraSpaceForMPR(i) := commitData.io.wdata(i))
+    extraSpaceForMPR := dispatchData.io.wdata
+
     state := s_extrawalk
     XSDebug("roq full, switched to s_extrawalk. needExtraSpaceForMPR: %b\n", needExtraSpaceForMPR.asUInt)
   }
-
-  // when exception occurs, cancels all
+  // when exception occurs, cancels all and switch to s_idle
   when (io.redirectOut.valid) {
     state := s_idle
   }
 
+
   /**
-    * pointers
+    * pointers and counters
     */
+  val commitCnt = PopCount(io.commits.valid)
   when (io.redirectOut.valid) {
     deqPtrVec := VecInit((0 until CommitWidth).map(_.U.asTypeOf(new RoqPtr)))
-  }.elsewhen(state === s_idle) {
+  }.elsewhen (state === s_idle) {
     deqPtrVec := deqPtrVec.map(_ + commitCnt)
+    XSInfo(commitCnt > 0.U, "retired %d insts\n", commitCnt)
   }
 
   when (io.redirectOut.valid) {
@@ -404,7 +401,17 @@ class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
   }.elsewhen (io.redirect.valid) {
     enqPtr := io.redirect.bits.roqIdx + Mux(io.redirect.bits.flushItself(), 0.U, 1.U)
   }.otherwise {
-    enqPtr := enqPtr + firedDispatch
+    enqPtr := enqPtr + dispatchNum
+  }
+
+  val thisCycleWalkCount = Mux(walkFinished, walkCounter, CommitWidth.U)
+  when (io.redirect.valid && state =/= s_extrawalk) {
+    walkPtrVec := Mux(state === s_walk,
+      VecInit(walkPtrVec.map(_ - thisCycleWalkCount)),
+      VecInit((0 until CommitWidth).map(i => enqPtr - (i+1).U))
+    )
+  }.elsewhen (state === s_walk) {
+    walkPtrVec := VecInit(walkPtrVec.map(_ - CommitWidth.U))
   }
 
   val lastCycleRedirect = RegNext(io.redirect.valid)
@@ -413,7 +420,7 @@ class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
   validCounter := Mux(io.redirectOut.valid,
     0.U,
     Mux(state === s_idle,
-      (validCounter - commitCnt) + firedDispatch,
+      (validCounter - commitCnt) + dispatchNum,
       trueValidCounter
     )
   )
@@ -421,47 +428,44 @@ class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
   allowEnqueue := Mux(io.redirectOut.valid,
     true.B,
     Mux(state === s_idle,
-      validCounter + firedDispatch <= (RoqSize - RenameWidth).U,
+      validCounter + dispatchNum <= (RoqSize - RenameWidth).U,
       trueValidCounter <= (RoqSize - RenameWidth).U
     )
   )
 
+  val currentWalkPtr = Mux(state === s_walk || state === s_extrawalk, walkPtr, enqPtr - 1.U)
+  val redirectWalkDistance = distanceBetween(currentWalkPtr, io.redirect.bits.roqIdx)
+  when (io.redirect.valid) {
+    walkCounter := Mux(state === s_walk,
+      redirectWalkDistance + io.redirect.bits.flushItself() - commitCnt,
+      redirectWalkDistance + io.redirect.bits.flushItself()
+    )
+  }.elsewhen (state === s_walk) {
+    walkCounter := walkCounter - commitCnt
+    XSInfo(p"rolling back: $enqPtr $deqPtr walk $walkPtr walkcnt $walkCounter\n")
+  }
+
+
   /**
     * States
-    * We put all the stage changes here.
+    * We put all the stage bits changes here.
 
     * All events: (1) enqueue (dispatch); (2) writeback; (3) cancel; (4) dequeue (commit);
-    * All states: (1) valid; (2) writebacked;
+    * All states: (1) valid; (2) writebacked; (3) flagBkup
     */
-  // write
   // enqueue logic writes 6 valid
   for (i <- 0 until RenameWidth) {
-    when(io.enq.req(i).valid && io.enq.canAccept && !io.redirect.valid){
+    when (canEnqueue(i) && !io.redirect.valid) {
       valid(enqPtrVec(i).value) := true.B
     }
   }
   // dequeue/walk logic writes 6 valid, dequeue and walk will not happen at the same time
-  for(i <- 0 until CommitWidth){
-    switch(state){
-      is(s_idle){
-        when(io.commits.valid(i)){valid(deqPtrVec(i).value) := false.B}
-      }
-      is(s_walk){
-        val idx = walkPtrVec(i).value
-        when(shouldWalkVec(i)){
-          valid(idx) := false.B
-        }
-      }
+  for (i <- 0 until CommitWidth) {
+    when (io.commits.valid(i) && state =/= s_extrawalk) {
+      valid(commitReadAddr(i)) := false.B
     }
   }
-
-  // read
-  // enqueue logic reads 6 valid
-  // dequeue/walk logic reads 6 valid, dequeue and walk will not happen at the same time
-  // rollback reads all valid? is it necessary?
-
-  // reset
-  // when exception, reset all valid to false
+  // reset: when exception, reset all valid to false
   when (io.redirectOut.valid) {
     for (i <- 0 until RoqSize) {
       valid(i) := false.B
@@ -469,51 +473,31 @@ class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
   }
 
   // status field: writebacked
-
-  // write
   // enqueue logic set 6 writebacked to false
   for (i <- 0 until RenameWidth) {
-    when(io.enq.req(i).valid && io.enq.canAccept && !io.redirect.valid){
+    when (canEnqueue(i)) {
       writebacked(enqPtrVec(i).value) := false.B
     }
   }
   // writeback logic set numWbPorts writebacked to true
-  for(i <- 0 until numWbPorts) {
-    when(io.exeWbResults(i).fire()){
-      val wbIdxExt = io.exeWbResults(i).bits.uop.roqIdx
-      val wbIdx = wbIdxExt.value
+  for (i <- 0 until numWbPorts) {
+    when (io.exeWbResults(i).valid) {
+      val wbIdx = io.exeWbResults(i).bits.uop.roqIdx.value
       writebacked(wbIdx) := true.B
     }
   }
 
-  // read
-  // deqPtrWritebacked
-  // gen io.commits(i).valid read 6 (CommitWidth)
-
   // flagBkup
-  // write: update when enqueue
   // enqueue logic set 6 flagBkup at most
   for (i <- 0 until RenameWidth) {
-    when(io.enq.req(i).valid && io.enq.canAccept && !io.redirect.valid){
+    when (canEnqueue(i)) {
       flagBkup(enqPtrVec(i).value) := enqPtrVec(i).flag
     }
   }
-  // read: used in rollback logic
-  // all flagBkup will be used
 
-  // exuFflags
-  // write: writeback logic set numWbPorts exuFflags
-  for(i <- 0 until numWbPorts) {
-    when(io.exeWbResults(i).fire()){
-      val wbIdxExt = io.exeWbResults(i).bits.uop.roqIdx
-      val wbIdx = wbIdxExt.value
-      exuFflags(wbIdx) := io.exeWbResults(i).bits.fflags
-    }
-  }
-  // read: used in commit logic
-  // read CommitWidth exuFflags
-
-  // debug info
+  /**
+    * debug info
+    */
   XSDebug(p"enqPtr ${enqPtr} deqPtr ${deqPtr}\n")
   XSDebug("")
   for(i <- 0 until RoqSize){
@@ -525,7 +509,7 @@ class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
 
   for(i <- 0 until RoqSize) {
     if(i % 4 == 0) XSDebug("")
-    XSDebug(false, true.B, "%x ", microOp(i).cf.pc)
+    XSDebug(false, true.B, "%x ", debug_microOp(i).cf.pc)
     XSDebug(false, !valid(i), "- ")
     XSDebug(false, valid(i) && writebacked(i), "w ")
     XSDebug(false, valid(i) && !writebacked(i), "v ")
@@ -541,7 +525,7 @@ class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
   if(!env.FPGAPlatform) {
 
     //difftest signals
-    val firstValidCommit = (deqPtr + PriorityMux(validCommit, VecInit(List.tabulate(CommitWidth)(_.U)))).value
+    val firstValidCommit = (deqPtr + PriorityMux(io.commits.valid, VecInit(List.tabulate(CommitWidth)(_.U)))).value
 
     val skip = Wire(Vec(CommitWidth, Bool()))
     val wen = Wire(Vec(CommitWidth, Bool()))
@@ -554,7 +538,7 @@ class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
     for(i <- 0 until CommitWidth){
       // io.commits(i).valid
       val idx = deqPtrVec(i).value
-      val uop = microOp(idx)
+      val uop = debug_microOp(idx)
       val DifftestSkipSC = false
       if(!DifftestSkipSC){
         skip(i) := debug_exuDebug(idx).isMMIO && io.commits.valid(i)
@@ -575,16 +559,17 @@ class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
     }
 
     val scFailed = !diffTestDebugLrScValid(0) &&
-      microOp(deqPtr.value).ctrl.fuType === FuType.mou &&
-      (microOp(deqPtr.value).ctrl.fuOpType === LSUOpType.sc_d || microOp(deqPtr.value).ctrl.fuOpType === LSUOpType.sc_w)
+      debug_deqUop.ctrl.fuType === FuType.mou &&
+      (debug_deqUop.ctrl.fuOpType === LSUOpType.sc_d || debug_deqUop.ctrl.fuOpType === LSUOpType.sc_w)
 
     val instrCnt = RegInit(0.U(64.W))
+    val retireCounter = Mux(state === s_idle, commitCnt, 0.U)
     instrCnt := instrCnt + retireCounter
 
     XSDebug(difftestIntrNO =/= 0.U, "difftest intrNO set %x\n", difftestIntrNO)
     val retireCounterFix = Mux(io.redirectOut.valid, 1.U, retireCounter)
-    val retirePCFix = SignExt(Mux(io.redirectOut.valid, microOp(deqPtr.value).cf.pc, microOp(firstValidCommit).cf.pc), XLEN)
-    val retireInstFix = Mux(io.redirectOut.valid, microOp(deqPtr.value).cf.instr, microOp(firstValidCommit).cf.instr)
+    val retirePCFix = SignExt(Mux(io.redirectOut.valid, debug_deqUop.cf.pc, debug_microOp(firstValidCommit).cf.pc), XLEN)
+    val retireInstFix = Mux(io.redirectOut.valid, debug_deqUop.cf.instr, debug_microOp(firstValidCommit).cf.instr)
 
     ExcitingUtils.addSource(RegNext(retireCounterFix), "difftestCommit", ExcitingUtils.Debug)
     ExcitingUtils.addSource(RegNext(retirePCFix), "difftestThisPC", ExcitingUtils.Debug)//first valid PC

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -93,6 +93,7 @@ package object xiangshan {
     def apply() = UInt(2.W)
     def isLoadStore(commitType: UInt) = commitType(1)
     def lsInstIsStore(commitType: UInt) = commitType(0)
+    def isStore(commitType: UInt) = isLoadStore(commitType) && lsInstIsStore(commitType)
     def isBranch(commitType: UInt) = commitType(0) && !commitType(1)
   }
 


### PR DESCRIPTION
This pull request wraps data, deqPtr, enqPtr in Roq into separate modules. This helps physical design optimizations. 