### PR TITLE
LoadUnit, LoadQueue: add independent fp load wb port

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -244,7 +244,8 @@ class LsqWrappper extends XSModule with HasDCacheParameters {
     val loadIn = Vec(LoadPipelineWidth, Flipped(Valid(new LsPipelineBundle)))
     val storeIn = Vec(StorePipelineWidth, Flipped(Valid(new LsPipelineBundle)))
     val sbuffer = Vec(StorePipelineWidth, Decoupled(new DCacheWordReq))
-    val ldout = Vec(2, DecoupledIO(new ExuOutput)) // writeback store
+    val ldout = Vec(2, DecoupledIO(new ExuOutput)) // writeback int load
+    val fpout = Vec(2, DecoupledIO(new ExuOutput)) // writeback fp load
     val mmioStout = DecoupledIO(new ExuOutput) // writeback uncached store
     val forward = Vec(LoadPipelineWidth, Flipped(new LoadForwardQueryIO))
     val commits = Flipped(new RoqCommitIO)
@@ -284,6 +285,7 @@ class LsqWrappper extends XSModule with HasDCacheParameters {
   loadQueue.io.loadIn <> io.loadIn
   loadQueue.io.storeIn <> io.storeIn
   loadQueue.io.ldout <> io.ldout
+  loadQueue.io.fpout <> io.fpout
   loadQueue.io.commits <> io.commits
   loadQueue.io.rollback <> io.rollback
   loadQueue.io.dcache <> io.dcache


### PR DESCRIPTION
Fp load uses different wb port from int load for 2 reasons:
* Fp load needs recode, which is quite slow. We need one complete cycle
for recoding.
* Fp load data has nothing to do with int load data. There is no reason
to mix them together.

An extra recode stage (load_s3) is added for fp load, while int load will
still be writebackd at load_s2.