### PR TITLE
icache: change icache miss perf register condition.

### DIFF
--- a/src/main/scala/xiangshan/cache/icache.scala
+++ b/src/main/scala/xiangshan/cache/icache.scala
@@ -477,7 +477,7 @@ class ICache extends ICacheModule
   //Performance Counter
   if (!env.FPGAPlatform ) {
     ExcitingUtils.addSource( s3_valid && !blocking, "perfCntIcacheReqCnt", Perf)
-    ExcitingUtils.addSource( s3_valid && !blocking && s3_miss, "perfCntIcacheMissCnt", Perf)
+    ExcitingUtils.addSource( s3_miss && blocking && io.resp.fire(), "perfCntIcacheMissCnt", Perf)
   }
 }
 


### PR DESCRIPTION
In case that the s3 miss request is flushed but it is replay again in
s3, resulting in the counter increasing twice or more.