### PR TITLE
L3,bank: modify address to avoid dead setBits

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -7,7 +7,8 @@ import chisel3.util._
 import freechips.rocketchip.diplomacy.{AddressSet, LazyModule, LazyModuleImp}
 import freechips.rocketchip.tilelink.{TLBuffer, TLFuzzer, TLIdentityNode, TLXbar}
 import utils.DebugIdentityNode
-import xiangshan.{HasXSParameter, XSCore}
+import utils.XSInfo
+import xiangshan.{HasXSParameter, XSCore, HasXSLog}
 import sifive.blocks.inclusivecache.{CacheParameters, InclusiveCache, InclusiveCacheMicroParameters}
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp, AddressSet}
 import freechips.rocketchip.tilelink.{TLBundleParameters, TLCacheCork, TLBuffer, TLClientNode, TLIdentityNode, TLXbar, TLWidthWidget, TLFilter, TLToAXI4}
@@ -42,6 +43,51 @@ class DummyCore()(implicit p: Parameters) extends LazyModule {
   }
 }
 
+
+class BankAddressConvertor(index: Int, bankBits: Int, blockBits: Int, recover: Boolean = false)(implicit p: Parameters) extends LazyModule {
+  val node = TLIdentityNode()
+
+  def shrink(addr: UInt): UInt = {
+    val msb = addr.getWidth - 1
+    Cat(0.U(bankBits.W), addr(msb, bankBits + blockBits), addr(blockBits - 1, 0))
+  }
+
+  def extend(addr: UInt): UInt = {
+    val msb = addr.getWidth - 1
+    Cat(addr(msb - bankBits, blockBits), index.U(bankBits.W), addr(blockBits - 1, 0))
+  }
+
+  lazy val module = new LazyModuleImp(this) with HasXSLog {
+    (node.in zip node.out) foreach { case ((in, _), (out, _)) =>
+      out <> in
+      if (!recover) {
+        out.a.bits.address := shrink(in.a.bits.address)
+        out.c.bits.address := shrink(in.c.bits.address)
+        in.b.bits.address := shrink(out.b.bits.address)
+
+        XSInfo(out.a.fire(), s"before bank $index A in addr %x -> out addr %x\n", in.a.bits.address, out.a.bits.address)
+        XSInfo(out.b.fire(), s"before bank $index B out addr %x -> in addr %x\n", out.b.bits.address, in.b.bits.address)
+        XSInfo(out.c.fire(), s"before bank $index C in addr %x -> out addr %x\n", in.c.bits.address, out.c.bits.address)
+      }
+      else {
+        out.a.bits.address := extend(in.a.bits.address)
+        out.c.bits.address := extend(in.c.bits.address)
+        in.b.bits.address := extend(out.b.bits.address)
+
+        XSInfo(out.a.fire(), s"after bank $index A in addr %x -> out addr %x\n", in.a.bits.address, out.a.bits.address)
+        XSInfo(out.b.fire(), s"after bank $index B out addr %x -> out addr %x\n", out.b.bits.address, in.b.bits.address)
+        XSInfo(out.c.fire(), s"after bank $index C in addr %x -> out addr %x\n", in.c.bits.address, out.c.bits.address)
+      }
+    }
+  }
+}
+
+object BankAddressConvertor {
+  def apply(index: Int, bankBits: Int, blockBits: Int, recover: Boolean)(implicit p: Parameters) = {
+    val bankAddressConvertor = LazyModule(new BankAddressConvertor(index, bankBits, blockBits, recover))
+    bankAddressConvertor.node
+  }
+}
 
 class XSSoc()(implicit p: Parameters) extends LazyModule with HasSoCParameter {
   // CPU Cores
@@ -131,11 +177,11 @@ class XSSoc()(implicit p: Parameters) extends LazyModule with HasSoCParameter {
 
   def bankFilter(bank: Int) = AddressSet(
     base = bank * L3BlockSize,
-    mask = ~BigInt((L3NBanks -1) * L3BlockSize))
+    mask = ~BigInt((L3NBanks - 1) * L3BlockSize))
 
   for(i <- 0 until L3NBanks) {
     val filter = TLFilter(TLFilter.mSelectIntersect(bankFilter(i)))
-    l3_banks(i).node := TLBuffer() := DebugIdentityNode() := filter := l3_xbar
+    l3_banks(i).node := BankAddressConvertor(i, log2Ceil(L3NBanks), log2Ceil(L3BlockSize), recover = false) := TLBuffer() := DebugIdentityNode() := filter := l3_xbar
   }
 
   for(i <- 0 until L3NBanks) {
@@ -144,6 +190,7 @@ class XSSoc()(implicit p: Parameters) extends LazyModule with HasSoCParameter {
       TLToAXI4() :=
       TLWidthWidget(L3BusWidth / 8) :=
       TLCacheCork() :=
+      BankAddressConvertor(i, log2Ceil(L3NBanks), log2Ceil(L3BlockSize), recover = true) :=
       l3_banks(i).node
   }
 


### PR DESCRIPTION
Make L3 cache see the address without fixed bankBits.

Example address convert log (microbench)

## Bank 0

```
[INFO ][time= 2049] TOP.XSSimSoC.soc.c: before bank 0 A in addr 0080000000 -> out addr 0020000000
[INFO ][time= 2052] TOP.XSSimSoC.soc.c_4: after bank 0 A in addr 0020000000 -> out addr 0080000000
[INFO ][time= 2238] TOP.XSSimSoC.soc.c: before bank 0 A in addr 0080004100 -> out addr 0020001040
[INFO ][time= 2239] TOP.XSSimSoC.soc.c: before bank 0 A in addr 0080005900 -> out addr 0020001640
[INFO ][time= 2241] TOP.XSSimSoC.soc.c_4: after bank 0 A in addr 0020001040 -> out addr 0080004100
[INFO ][time= 2244] TOP.XSSimSoC.soc.c_4: after bank 0 A in addr 0020001640 -> out addr 0080005900
[INFO ][time= 2466] TOP.XSSimSoC.soc.c: before bank 0 A in addr 0080004c00 -> out addr 0020001300
[INFO ][time= 2469] TOP.XSSimSoC.soc.c_4: after bank 0 A in addr 0020001300 -> out addr 0080004c00
```

## Bank 1

```
[INFO ][time=2237] TOP.XSSimSoC.soc.c_1: before bank 1 A in addr 0080005e40 -> out addr 0020001780
[INFO ][time=2240] TOP.XSSimSoC.soc.c_5: after bank 1 A in addr 0020001780 -> out addr 0080005e40
[INFO ][time=2325] TOP.XSSimSoC.soc.c_1: before bank 1 A in addr 0080005540 -> out addr 0020001540
[INFO ][time=2328] TOP.XSSimSoC.soc.c_5: after bank 1 A in addr 0020001540 -> out addr 0080005540
[INFO ][time=2510] TOP.XSSimSoC.soc.c_1: before bank 1 A in addr 0080005840 -> out addr 0020001600
[INFO ][time=2513] TOP.XSSimSoC.soc.c_5: after bank 1 A in addr 0020001600 -> out addr 0080005840
[INFO ][time=2546] TOP.XSSimSoC.soc.c_1: before bank 1 A in addr 0080004b40 -> out addr 00200012c0
[INFO ][time=2549] TOP.XSSimSoC.soc.c_5: after bank 1 A in addr 00200012c0 -> out addr 0080004b40
[INFO ][time=2582] TOP.XSSimSoC.soc.c_1: before bank 1 A in addr 0080004540 -> out addr 0020001140
[INFO ][time=2585] TOP.XSSimSoC.soc.c_5: after bank 1 A in addr 0020001140 -> out addr 0080004540
[INFO ][time=2661] TOP.XSSimSoC.soc.c_1: before bank 1 A in addr 0080004c40 -> out addr 0020001300
[INFO ][time=2664] TOP.XSSimSoC.soc.c_5: after bank 1 A in addr 0020001300 -> out addr 0080004c40
[INFO ][time=3912] TOP.XSSimSoC.soc.c_1: before bank 1 A in addr 0080004a40 -> out addr 0020001280
[INFO ][time=3915] TOP.XSSimSoC.soc.c_5: after bank 1 A in addr 0020001280 -> out addr 0080004a40
```