### PR TITLE
Revert "LoadQueue: select load refilled this cycle for wb"

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -290,7 +290,7 @@ class LoadQueue extends XSModule
   // Stage 0
   // Generate writeback indexes
   val loadWbSelVec = VecInit((0 until LoadQueueSize).map(i => {
-    allocated(i) && !writebacked(i) && (datavalid(i) || dataModule.io.refill.wen(i))
+    allocated(i) && datavalid(i) && !writebacked(i)
   })).asUInt() // use uint instead vec to reduce verilog lines
   val loadEvenSelVec = VecInit((0 until LoadQueueSize/2).map(i => {loadWbSelVec(2*i)}))
   val loadOddSelVec = VecInit((0 until LoadQueueSize/2).map(i => {loadWbSelVec(2*i+1)}))


### PR DESCRIPTION
This reverts commit 2e0406ca0691ebda089d4b26e1012594c7544e7f.

* It causes CoreMark IPC drop 0.1 for unknown reasons
* As it may harm timing as well, we remove it from master for now