### PR TITLE
DCache: fixed sync bus between probe and LoadPipe, StorePipe and Atom…

### DIFF
--- a/src/main/scala/xiangshan/cache/dcacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcacheWrapper.scala
@@ -441,28 +441,28 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
     val atomics_addr_matches = VecInit(atomics.io.inflight_req_block_addrs map (entry => entry.valid && entry.bits === get_block_addr(addr)))
     val atomics_addr_match = atomics_addr_matches.reduce(_||_)
 
-    val prober_addr_match = prober.io.inflight_req_block_addr.valid && prober.io.inflight_req_block_addr.bits === get_block_addr(addr)
+    val prober_idx_match = prober.io.inflight_req_block_addr.valid && get_idx(prober.io.inflight_req_block_addr.bits) === get_idx(addr)
 
     val miss_idx_matches = VecInit(missQueue.io.inflight_req_idxes map (entry => entry.valid && entry.bits === get_idx(addr)))
     val miss_idx_match = miss_idx_matches.reduce(_||_)
 
-    store_addr_match || atomics_addr_match || prober_addr_match || miss_idx_match
+    store_addr_match || atomics_addr_match || prober_idx_match || miss_idx_match
   }
 
   def block_store(addr: UInt) = {
-    val prober_addr_match = prober.io.inflight_req_block_addr.valid && prober.io.inflight_req_block_addr.bits === get_block_addr(addr)
+    val prober_idx_match = prober.io.inflight_req_block_addr.valid && get_idx(prober.io.inflight_req_block_addr.bits) === get_idx(addr)
 
     val miss_idx_matches = VecInit(missQueue.io.inflight_req_idxes map (entry => entry.valid && entry.bits === get_idx(addr)))
     val miss_idx_match = miss_idx_matches.reduce(_||_)
-    prober_addr_match || miss_idx_match
+    prober_idx_match || miss_idx_match
   }
 
   def block_atomics(addr: UInt) = {
-    val prober_addr_match = prober.io.inflight_req_block_addr.valid && prober.io.inflight_req_block_addr.bits === get_block_addr(addr)
+    val prober_idx_match = prober.io.inflight_req_block_addr.valid && get_idx(prober.io.inflight_req_block_addr.bits) === get_idx(addr)
 
     val miss_idx_matches = VecInit(missQueue.io.inflight_req_idxes map (entry => entry.valid && entry.bits === get_idx(addr)))
     val miss_idx_match = miss_idx_matches.reduce(_||_)
-    prober_addr_match || miss_idx_match
+    prober_idx_match || miss_idx_match
   }
 
   def block_miss(addr: UInt) = {
@@ -475,11 +475,11 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   }
 
   def block_probe(addr: UInt) = {
-    val store_addr_matches = VecInit(stu.io.inflight_req_block_addrs map (entry => entry.valid && entry.bits === get_block_addr(addr)))
-    val store_addr_match = store_addr_matches.reduce(_||_)
+    val store_idx_matches = VecInit(stu.io.inflight_req_block_addrs map (entry => entry.valid && get_idx(entry.bits) === get_idx(addr)))
+    val store_idx_match = store_idx_matches.reduce(_||_)
 
-    val atomics_addr_matches = VecInit(atomics.io.inflight_req_block_addrs map (entry => entry.valid && entry.bits === get_block_addr(addr)))
-    val atomics_addr_match = atomics_addr_matches.reduce(_||_)
+    val atomics_idx_matches = VecInit(atomics.io.inflight_req_block_addrs map (entry => entry.valid && get_idx(entry.bits) === get_idx(addr)))
+    val atomics_idx_match = atomics_idx_matches.reduce(_||_)
 
     val lrsc_addr_match = atomics.io.block_probe_addr.valid && atomics.io.block_probe_addr.bits === get_block_addr(addr)
 
@@ -489,7 +489,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
     // the missed req
     val miss_req_idx_match = missReq.fire() && get_idx(missReq.bits.addr) === get_idx(addr)
 
-    store_addr_match || atomics_addr_match || lrsc_addr_match || miss_idx_match || miss_req_idx_match
+    store_idx_match || atomics_idx_match || lrsc_addr_match || miss_idx_match || miss_req_idx_match
   }
 
   def block_decoupled[T <: Data](source: DecoupledIO[T], sink: DecoupledIO[T], block_signal: Bool) = {


### PR DESCRIPTION
…icsPipe.

Now, every pipe directly carries the old_repl_meta to missQueue.
So probe should block every pipe with same set req.
In case they try to replace the block probe was manipulating.

The buggy case happens this way:
1. Probe block A, which resides in set x, way y.
2. Probe has done almost everything except meta data update.
3. StorePipe handles block B, which missed in cache, so it try to
   replace set x, way y. Because Probe haven't update meta data, StorePipe
   gets a old copy of meta data, which means it will try to evict block A.
4. Probe finally update meta.
5. MissQueue accept miss request for block B from StorePipe, with the
   old_repl_meta, MissQueue tries to evict block A, although it's already
   probed out.