### PR TITLE
sbuffer: add sq empty check

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -250,6 +250,7 @@ class MemBlockImp
 
   // LSQ to store buffer
   lsq.io.sbuffer        <> sbuffer.io.in
+  lsq.io.sqempty        <> sbuffer.io.sqempty
 
   // Sbuffer
   sbuffer.io.dcache     <> dcache.io.lsu.store

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -51,6 +51,7 @@ class LsqWrappper extends XSModule with HasDCacheParameters {
     val uncache = new DCacheWordIO
     val roqDeqPtr = Input(new RoqPtr)
     val exceptionAddr = new ExceptionAddrIO
+    val sqempty = Output(Bool())
   })
 
   val loadQueue = Module(new LoadQueue)
@@ -102,6 +103,8 @@ class LsqWrappper extends XSModule with HasDCacheParameters {
 
   loadQueue.io.load_s1 <> io.forward
   storeQueue.io.forward <> io.forward // overlap forwardMask & forwardData, DO NOT CHANGE SEQUENCE
+
+  storeQueue.io.sqempty <> io.sqempty
 
   io.exceptionAddr.vaddr := Mux(io.exceptionAddr.isStore, storeQueue.io.exceptionAddr.vaddr, loadQueue.io.exceptionAddr.vaddr)
 

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -43,6 +43,7 @@ class StoreQueue extends XSModule with HasDCacheParameters with HasCircularQueue
     val roqDeqPtr = Input(new RoqPtr)
     // val refill = Flipped(Valid(new DCacheLineReq ))
     val exceptionAddr = new ExceptionAddrIO
+    val sqempty = Output(Bool())
   })
 
   // data modules
@@ -359,6 +360,12 @@ class StoreQueue extends XSModule with HasDCacheParameters with HasCircularQueue
       validCounter + enqNumber <= (StoreQueueSize - RenameWidth).U
     )
   )
+
+  // io.sqempty will be used by sbuffer
+  // We delay it for 1 cycle for better timing
+  // When sbuffer need to check if it is empty, the pipeline is blocked, which means delay io.sqempty
+  // for 1 cycle will also promise that sq is empty in that cycle
+  io.sqempty := RegNext(enqPtrExt(0).value === deqPtrExt(0).value && enqPtrExt(0).flag === deqPtrExt(0).flag)
 
   // debug info
   XSDebug("enqPtrExt %d:%d deqPtrExt %d:%d\n", enqPtrExt(0).flag, enqPtr, deqPtrExt(0).flag, deqPtr)

--- a/src/main/scala/xiangshan/mem/sbuffer/NewSbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/NewSbuffer.scala
@@ -108,6 +108,7 @@ class NewSbuffer extends XSModule with HasSbufferCst {
     val in = Vec(StorePipelineWidth, Flipped(Decoupled(new DCacheWordReq)))  //Todo: store logic only support Width == 2 now
     val dcache = new DCacheLineIO
     val forward = Vec(LoadPipelineWidth, Flipped(new LoadForwardQueryIO))
+    val sqempty = Input(Bool())
     val flush = new Bundle {
       val valid = Input(Bool())
       val empty = Output(Bool())
@@ -291,7 +292,7 @@ class NewSbuffer extends XSModule with HasSbufferCst {
 
   do_eviction := validCount >= 12.U
 
-  io.flush.empty := empty
+  io.flush.empty := empty && io.sqempty
   lru.io.flush := sbuffer_state === x_drain_sbuffer && empty
   switch(sbuffer_state){
     is(x_idle){


### PR DESCRIPTION
When sbuffer checks if it is empty, it needs to check if sq is also empty
so there is no pending store. Errors will emerge rarely if we do not
check sq.