### PR TITLE
Use DontCare to remove L2 inner A channel's data field.

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.diplomacy.{AddressSet, LazyModule, LazyModuleImp}
 import freechips.rocketchip.tilelink.{BankBinder, TLBuffer, TLBundleParameters, TLCacheCork, TLClientNode, TLFilter, TLFuzzer, TLIdentityNode, TLToAXI4, TLWidthWidget, TLXbar}
-import utils.DebugIdentityNode
+import utils.{DebugIdentityNode, DataDontCareNode}
 import utils.XSInfo
 import xiangshan.{HasXSParameter, XSCore, HasXSLog}
 import sifive.blocks.inclusivecache.{CacheParameters, InclusiveCache, InclusiveCacheMicroParameters}
@@ -102,7 +102,7 @@ class XSSoc()(implicit p: Parameters) extends LazyModule with HasSoCParameter {
     l2_xbar(i) := TLBuffer() := DebugIdentityNode() := xs_core(i).l2Prefetcher.clientNode
     mmioXbar   := TLBuffer() := DebugIdentityNode() := xs_core(i).memBlock.uncache.clientNode
     mmioXbar   := TLBuffer() := DebugIdentityNode() := xs_core(i).instrUncache.clientNode
-    l2cache(i).node := TLBuffer() := DebugIdentityNode() := l2_xbar(i)
+    l2cache(i).node := DataDontCareNode(a = true, b = true) := TLBuffer() := DebugIdentityNode() := l2_xbar(i)
     l3_xbar := TLBuffer() := DebugIdentityNode() := l2cache(i).node
   }
 

--- a/src/main/scala/utils/DataDontCareNode.scala
+++ b/src/main/scala/utils/DataDontCareNode.scala
@@ -1,0 +1,44 @@
+package utils
+
+import chisel3._
+import chipsalliance.rocketchip.config.Parameters
+import chisel3.util.DecoupledIO
+import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
+import freechips.rocketchip.tilelink.{TLBundle, TLClientNode, TLIdentityNode, TLMasterParameters, TLMasterPortParameters}
+import xiangshan.HasXSLog
+
+class DataDontCareNode(a: Boolean = false, b: Boolean = false, c: Boolean = false, d: Boolean = false)(implicit p: Parameters) extends LazyModule  {
+
+  val node = TLIdentityNode()
+
+  val n = TLClientNode(Seq(TLMasterPortParameters.v1(
+    Seq(
+      TLMasterParameters.v1("DataDontCareNode")
+    )
+  )))
+
+  lazy val module = new LazyModuleImp(this) with HasXSLog with HasTLDump{
+    val (out, _) = node.out(0)
+    val (in, _) = node.in(0)
+
+    if (a) {
+      out.a.bits.data := DontCare
+    }
+    if (b) {
+      in.b.bits.data := DontCare
+    }
+    if (c) {
+      out.c.bits.data := DontCare
+    }
+    if (d) {
+      in.d.bits.data := DontCare
+    }
+  }
+}
+
+object DataDontCareNode {
+  def apply(a: Boolean = false, b: Boolean = false, c: Boolean = false, d: Boolean = false)(implicit p: Parameters): TLIdentityNode = {
+    val dataDontCareNode = LazyModule(new DataDontCareNode(a, b, c, d))
+    dataDontCareNode.node
+  }
+}


### PR DESCRIPTION
This effectly reduces the number of bus data wires from 256 * 3 to 256 * 2.

Use DataDontCareNode to add DontCare to the tilelink nodes you are
interested in.