### PR TITLE
LoadUnit: add load_s3 for better timing

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -212,6 +212,7 @@ class MemBlockImp
     // passdown to lsq
     lsq.io.loadIn(i)              <> loadUnits(i).io.lsq.loadIn
     lsq.io.ldout(i)               <> loadUnits(i).io.lsq.ldout
+    lsq.io.load_s2(i)             <> loadUnits(i).io.lsq.load_s2
   }
 
   // StoreUnit

--- a/src/main/scala/xiangshan/mem/Memend.scala
+++ b/src/main/scala/xiangshan/mem/Memend.scala
@@ -51,7 +51,7 @@ class LoadForwardQueryIO extends XSBundle {
   val mask = Output(UInt(8.W))
   val uop = Output(new MicroOp) // for replay
   val pc = Output(UInt(VAddrBits.W)) //for debug
-  val valid = Output(Bool()) //for debug
+  val valid = Output(Bool())
 
   val forwardMask = Input(Vec(8, Bool()))
   val forwardData = Input(Vec(8, UInt(8.W)))

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -45,6 +45,7 @@ class LsqWrappper extends XSModule with HasDCacheParameters {
     val ldout = Vec(2, DecoupledIO(new ExuOutput)) // writeback int load
     val mmioStout = DecoupledIO(new ExuOutput) // writeback uncached store
     val forward = Vec(LoadPipelineWidth, Flipped(new LoadForwardQueryIO))
+    val load_s2 = Vec(LoadPipelineWidth, Flipped(new LoadForwardQueryIO))
     val commits = Flipped(new RoqCommitIO)
     val rollback = Output(Valid(new Redirect))
     val dcache = Flipped(ValidIO(new Refill))
@@ -103,6 +104,8 @@ class LsqWrappper extends XSModule with HasDCacheParameters {
 
   loadQueue.io.load_s1 <> io.forward
   storeQueue.io.forward <> io.forward // overlap forwardMask & forwardData, DO NOT CHANGE SEQUENCE
+
+  loadQueue.io.load_s2 <> io.load_s2
 
   storeQueue.io.sqempty <> io.sqempty
 

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -27,15 +27,18 @@ object LqPtr extends HasXSParameter {
 trait HasLoadHelper { this: XSModule =>
   def rdataHelper(uop: MicroOp, rdata: UInt): UInt = {
     val fpWen = uop.ctrl.fpWen
-    LookupTree(uop.ctrl.fuOpType, List(
-      LSUOpType.lb   -> SignExt(rdata(7, 0) , XLEN),
-      LSUOpType.lh   -> SignExt(rdata(15, 0), XLEN),
-      LSUOpType.lw   -> Mux(fpWen, rdata, SignExt(rdata(31, 0), XLEN)),
-      LSUOpType.ld   -> Mux(fpWen, rdata, SignExt(rdata(63, 0), XLEN)),
-      LSUOpType.lbu  -> ZeroExt(rdata(7, 0) , XLEN),
-      LSUOpType.lhu  -> ZeroExt(rdata(15, 0), XLEN),
-      LSUOpType.lwu  -> ZeroExt(rdata(31, 0), XLEN),
-    ))
+    Mux(fpWen,
+      rdata,
+      LookupTree(uop.ctrl.fuOpType, List(
+        LSUOpType.lb   -> SignExt(rdata(7, 0) , XLEN),
+        LSUOpType.lh   -> SignExt(rdata(15, 0), XLEN),
+        LSUOpType.lw   -> SignExt(rdata(31, 0), XLEN),
+        LSUOpType.ld   -> SignExt(rdata(63, 0), XLEN),
+        LSUOpType.lbu  -> ZeroExt(rdata(7, 0) , XLEN),
+        LSUOpType.lhu  -> ZeroExt(rdata(15, 0), XLEN),
+        LSUOpType.lwu  -> ZeroExt(rdata(31, 0), XLEN),
+      ))
+    )
   }
 
   def fpRdataHelper(uop: MicroOp, rdata: UInt): UInt = {


### PR DESCRIPTION
* load_s3 is used to write data retrieved from dcache to GPRs and RSs
* Will cause IPC loss