### PR TITLE
Fix l1plus double hit problem and random replace bug

### DIFF
--- a/src/main/scala/utils/Replacement.scala
+++ b/src/main/scala/utils/Replacement.scala
@@ -47,7 +47,7 @@ object ReplacementPolicy {
 
 class RandomReplacement(n_ways: Int) extends ReplacementPolicy {
   private val replace = Wire(Bool())
-  replace := false.B
+  replace := true.B
   def nBits = 16
   def perSet = false
   private val lfsr = LFSR(nBits, replace)

--- a/src/test/scala/cache/ReplaceTest.scala
+++ b/src/test/scala/cache/ReplaceTest.scala
@@ -78,7 +78,7 @@ class ReplaceTest extends AnyFlatSpec
             var tag = 0
 
             for(i <- 0 until testnumber){
-                if(i%5 == 0){ tag = randomGen.nextInt(maxTag + 1)  }
+                if(i%1 == 0){ tag = randomGen.nextInt(maxTag + 1)  }
                 c.io.req.valid.poke(true.B)
                 c.io.req.bits.tag.poke(tag.U)
                 if(c.io.resp.bits.hit.peek().litToBoolean){ hitCounter = hitCounter + 1}


### PR DESCRIPTION
We use s1_addr address to keep the index for reading valid array when pipeline is blocking.