### PR TITLE
Fix replacement policy and change replacement policies for L1I, L1+

### DIFF
--- a/src/main/scala/utils/Replacement.scala
+++ b/src/main/scala/utils/Replacement.scala
@@ -72,7 +72,6 @@ abstract class SetAssocReplacementPolicy {
   def access(set: UInt, touch_way: UInt): Unit
   def access(sets: Seq[UInt], touch_ways: Seq[Valid[UInt]]): Unit
   def way(set: UInt): UInt
-  def miss(set: UInt): Unit
 }
 
 

--- a/src/main/scala/utils/Replacement.scala
+++ b/src/main/scala/utils/Replacement.scala
@@ -147,13 +147,8 @@ class TrueLRU(n_ways: Int) extends ReplacementPolicy {
     OHToUInt(mruWayDec)
   }
 
-  def way = {
-    val refillWay = get_replace_way(state_reg)
-    access(refillWay)
-    refillWay
-  }
-
-  def miss = {}
+  def way = get_replace_way(state_reg)
+  def miss = access(way)
   def hit = {}
   @deprecated("replace 'replace' with 'way' from abstract class ReplacementPolicy","Rocket Chip 2020.05")
   def replace: UInt = way
@@ -287,13 +282,9 @@ class PseudoLRU(n_ways: Int) extends ReplacementPolicy {
 
   def get_replace_way(state: UInt): UInt = get_replace_way(state, n_ways)
 
-  def way = {
-    val refillWay = get_replace_way(state_reg)
-    access(refillWay)
-    refillWay
-  }
+  def way = get_replace_way(state_reg)
+  def miss = access(way)
   def hit = {}
-  def miss = {}
 }
 
 class SeqPLRU(n_sets: Int, n_ways: Int) extends SeqReplacementPolicy {
@@ -340,12 +331,8 @@ class SetAssocLRU(n_sets: Int, n_ways: Int, policy: String) extends SetAssocRepl
     }
   }
 
-  def way(set: UInt) = {
-    val refillWay = logic.get_replace_way(state_vec(set))
-    access(set, refillWay)
-    refillWay
-  }
-  def miss(set: UInt) = {}
+  def way(set: UInt) = logic.get_replace_way(state_vec(set))
+
 }
 
 class SetAssocRandom(n_sets : Int, n_ways: Int) extends SetAssocReplacementPolicy {

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -203,13 +203,14 @@ trait HasXSParameter {
   val icacheParameters = ICacheParameters(
     tagECC = Some("parity"),
     dataECC = Some("parity"),
-    replacer = Some("setlru"),
+    replacer = Some("setplru"),
     nMissEntries = 2
   )
 
   val l1plusCacheParameters = L1plusCacheParameters(
     tagECC = Some("secded"),
     dataECC = Some("secded"),
+    replacer = Some("setplru"),
     nMissEntries = 8
   )
 

--- a/src/main/scala/xiangshan/cache/L1plusCache.scala
+++ b/src/main/scala/xiangshan/cache/L1plusCache.scala
@@ -49,6 +49,7 @@ trait HasL1plusCacheParameters extends HasL1CacheParameters {
   def bankNum = 2
   def bankRows = blockRows / bankNum
   def blockEcodedBits = blockRows * encRowBits
+  def plruAccessNum = 2  //hit and miss
 
   def missQueueEntryIdWidth = log2Up(cfg.nMissEntries)
   // def icacheMissQueueEntryIdWidth = log2Up(icfg.nMissEntries)
@@ -91,6 +92,11 @@ object L1plusCacheMetadata {
     meta
   }
 }
+
+
+/*  tagIdx is from the io.in.req (Wire)
+ *  validIdx is from s1_addr (Register)
+ */
 
 class L1plusCacheMetaReadReq extends L1plusCacheBundle {
   val tagIdx    = UInt(idxBits.W)
@@ -384,6 +390,8 @@ class L1plusCacheImp(outer: L1plusCache) extends LazyModuleImp(outer) with HasL1
   pipe.io.data_resp <> dataArray.io.resp
   pipe.io.meta_read <> metaArray.io.read
   pipe.io.meta_resp <> metaArray.io.resp
+  pipe.io.miss_meta_write.valid := missQueue.io.meta_write.valid
+  pipe.io.miss_meta_write.bits <> missQueue.io.meta_write.bits
 
   missQueue.io.req <> pipe.io.miss_req
   bus.a <> missQueue.io.mem_acquire
@@ -479,6 +487,7 @@ class L1plusCachePipe extends L1plusCacheModule
     val meta_read  = DecoupledIO(new L1plusCacheMetaReadReq)
     val meta_resp  = Input(Vec(nWays, new L1plusCacheMetadata))
     val miss_req   = DecoupledIO(new L1plusCacheMissReq)
+    val miss_meta_write = Flipped(ValidIO(new L1plusCacheMetaWriteReq))
     val inflight_req_idxes = Output(Vec(2, Valid(UInt())))
     val empty = Output(Bool())
   })
@@ -557,7 +566,12 @@ class L1plusCachePipe extends L1plusCacheModule
 
   //replacement marker
   val replacer = cacheParams.replacement
-  when(s2_valid && s2_hit){ replacer.access(get_idx(s2_req.addr), s2_hit_way ) }
+  val (touch_sets, touch_ways) = ( Wire(Vec(plruAccessNum, UInt(log2Ceil(nSets).W))),  Wire(Vec(plruAccessNum, Valid(UInt(log2Ceil(nWays).W)))) )
+
+  touch_sets(0)       := get_idx(s2_req.addr)  
+  touch_ways(0).valid := s2_valid && s2_hit
+  touch_ways(0).bits  := s2_hit_way
+
 
   val data_resp = io.data_resp
   val s2_data = data_resp(s2_hit_way)
@@ -589,6 +603,11 @@ class L1plusCachePipe extends L1plusCacheModule
   io.miss_req.bits.cmd    := M_XRD
   io.miss_req.bits.addr   := s2_req.addr
   io.miss_req.bits.way_en := replaced_way_en
+
+  touch_sets(1)       := io.miss_meta_write.bits.tagIdx
+  touch_ways(1).valid := io.miss_meta_write.valid
+  touch_ways(1).bits  := OHToUInt(io.miss_meta_write.bits.way_en.asUInt)
+
 
   s2_passdown := s2_valid && ((s2_hit && io.resp.ready) || (!s2_hit && io.miss_req.ready))
 

--- a/src/main/scala/xiangshan/cache/L1plusCache.scala
+++ b/src/main/scala/xiangshan/cache/L1plusCache.scala
@@ -2,7 +2,7 @@ package xiangshan.cache
 
 import chisel3._
 import chisel3.util._
-import utils.{Code, ReplacementPolicy, HasTLDump, XSDebug, SRAMTemplate}
+import utils.{Code, ReplacementPolicy, HasTLDump, XSDebug, SRAMTemplate, XSPerf}
 import xiangshan.{HasXSLog}
 
 import chipsalliance.rocketchip.config.Parameters
@@ -634,6 +634,10 @@ class L1plusCachePipe extends L1plusCacheModule
         )
       }
   }
+
+  XSPerf("req", s0_valid)
+  XSPerf("miss", s2_valid && !s2_hit)
+
 }
 
 class L1plusCacheMissReq extends L1plusCacheBundle


### PR DESCRIPTION
1. ICache, L1plus Cache now support multi-access for plur state.
2. Delete state change in way method, instead use multi-access logic.