### PR TITLE
Roq: use exceptionVec.asUInt.orR to check whether there're exceptions

### DIFF
--- a/src/main/scala/xiangshan/backend/roq/Roq.scala
+++ b/src/main/scala/xiangshan/backend/roq/Roq.scala
@@ -415,7 +415,7 @@ class Roq(numWbPorts: Int) extends XSModule with HasCircularQueuePtrHelper {
   val intrBitSetReg = RegNext(io.csr.intrBitSet)
   val intrEnable = intrBitSetReg && !hasNoSpecExec && !CommitType.isLoadStore(deqDispatchData.commitType)
   val deqHasExceptionOrFlush = exceptionDataRead.valid && exceptionDataRead.bits.roqIdx === deqPtr
-  val deqHasException = deqHasExceptionOrFlush && !exceptionDataRead.bits.flushPipe
+  val deqHasException = deqHasExceptionOrFlush && exceptionDataRead.bits.exceptionVec.asUInt.orR
   val deqHasFlushPipe = deqHasExceptionOrFlush && exceptionDataRead.bits.flushPipe
   val exceptionEnable = writebacked(deqPtr.value) && deqHasException
   val isFlushPipe = writebacked(deqPtr.value) && deqHasFlushPipe


### PR DESCRIPTION
Previously, we use !flushPipe to reduce serveral or gates.
However, when an instruction has instruction page fault or access fault,
the instruction may be decoded as any instructions, which possibly generates flushPipe.
Thus, previously an instruction with exceptions may trigger a flushPipe instead of exceptions.

Now we use exceptionVec.asUInt.orR to see whether it has exceptions.