### PR TITLE
RS & DTLB: fix bug of dtlb's hit perf counter

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -243,6 +243,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     loadUnits(i).io.flush         <> io.fromCtrlBlock.flush
     loadUnits(i).io.tlbFeedback   <> reservationStations(i).io.memfeedback
     loadUnits(i).io.rsIdx         := reservationStations(i).io.rsIdx // TODO: beautify it
+    loadUnits(i).io.isFirstIssue  := reservationStations(i).io.isFirstIssue // NOTE: just for dtlb's perf cnt
     loadUnits(i).io.dtlb          <> dtlb.io.requestor(i)
     // get input form dispatch
     loadUnits(i).io.ldin          <> reservationStations(i).io.deq
@@ -276,6 +277,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     stu.io.flush       <> io.fromCtrlBlock.flush
     stu.io.tlbFeedback <> rs.io.memfeedback
     stu.io.rsIdx       <> rs.io.rsIdx
+    stu.io.isFirstIssue <> rs.io.isFirstIssue // NOTE: just for dtlb's perf cnt
     stu.io.dtlb        <> dtlbReq
     stu.io.stin        <> rs.io.deq
     stu.io.lsq         <> lsq.io.storeIn(i)

--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -121,6 +121,7 @@ class ReservationStation
 
     val memfeedback = if (feedback) Flipped(ValidIO(new RSFeedback)) else null
     val rsIdx = if (feedback) Output(UInt(log2Up(IssQueSize).W)) else null
+    val isFirstIssue = if (feedback) Output(Bool()) else null // NOTE: just use for tlb perf cnt
   })
 
   val select = Module(new ReservationStationSelect(exuCfg, srcLen, fastPortsCfg, slowPortsCfg, fixedDelay, fastWakeup, feedback))
@@ -186,6 +187,7 @@ class ReservationStation
 
   if (feedback) {
     io.rsIdx := RegNext(select.io.deq.bits) // NOTE: just for feeback
+    io.isFirstIssue := select.io.isFirstIssue
   }
   io.deq.bits := DontCare
   io.deq.bits.uop  := ctrl.io.out.bits
@@ -236,6 +238,7 @@ class ReservationStationSelect
     val deq = DecoupledIO(UInt(iqIdxWidth.W))
 
     val flushState = if (feedback) Input(Bool()) else null
+    val isFirstIssue = if (feedback) Output(Bool()) else null
   })
 
   def widthMap[T <: Data](f: Int => T) = VecInit((0 until iqSize).map(f))
@@ -421,6 +424,7 @@ class ReservationStationSelect
       // NOTE: maybe useless, for logical queue and phyical queue make this no sense
       XSPerf(s"replayTimeOfEntry${i}", io.memfeedback.valid && !io.memfeedback.bits.hit && io.memfeedback.bits.rsIdx === i.U)
     }
+    io.isFirstIssue := RegNext(ParallelPriorityMux(selectMask.asBools zip cntCountQueue) === 0.U) 
   }
   for(i <- 0 until iqSize) {
     if (i == 0) XSPerf("empty", io.numExist === 0.U)

--- a/src/main/scala/xiangshan/cache/ICache.scala
+++ b/src/main/scala/xiangshan/cache/ICache.scala
@@ -598,6 +598,7 @@ class ICache extends ICacheModule
   io.tlb.req.bits.cmd := TlbCmd.exec
   io.tlb.req.bits.roqIdx := DontCare
   io.tlb.req.bits.debug.pc := s2_req_pc
+  io.tlb.req.bits.debug.isFirstIssue := DontCare
 
   //To L1 plus
   io.mem_acquire <> icacheMissQueue.io.mem_acquire

--- a/src/main/scala/xiangshan/cache/TLB.scala
+++ b/src/main/scala/xiangshan/cache/TLB.scala
@@ -226,6 +226,7 @@ class TlbReq extends TlbBundle {
   val roqIdx = new RoqPtr
   val debug = new Bundle {
     val pc = UInt(XLEN.W)
+    val isFirstIssue = Bool()
   }
 
   override def toPrintable: Printable = {
@@ -530,10 +531,10 @@ class TLB(Width: Int, isDtlb: Boolean) extends TlbModule with HasCSRConst{
 
   if (isDtlb) {
     for (i <- 0 until Width) {
-      XSPerf("access" + Integer.toString(i, 10), validRegVec(i) && vmEnable)
+      XSPerf("access" + Integer.toString(i, 10), validRegVec(i) && vmEnable && RegNext(req(i).bits.debug.isFirstIssue))
     }
     for (i <- 0 until Width) {
-      XSPerf("miss" + Integer.toString(i, 10), validRegVec(i) && vmEnable && missVec(i))
+      XSPerf("miss" + Integer.toString(i, 10), validRegVec(i) && vmEnable && missVec(i) && RegNext(req(i).bits.debug.isFirstIssue))
     }
   } else {
     // NOTE: ITLB is blocked, so every resp will be valid only when hit

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -101,6 +101,7 @@ class AtomicsUnit extends XSModule with MemoryOpConstants{
     val is_lr = in.uop.ctrl.fuOpType === LSUOpType.lr_w || in.uop.ctrl.fuOpType === LSUOpType.lr_d
     io.dtlb.req.bits.cmd    := Mux(is_lr, TlbCmd.atom_read, TlbCmd.atom_write)
     io.dtlb.req.bits.debug.pc := in.uop.cf.pc
+    io.dtlb.req.bits.debug.isFirstIssue := false.B
 
     when(io.dtlb.resp.fire && !io.dtlb.resp.bits.miss){
       // exception handling

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -26,6 +26,7 @@ class LoadUnit_S0 extends XSModule {
     val dtlbReq = DecoupledIO(new TlbReq)
     val dcacheReq = DecoupledIO(new DCacheWordReq)
     val rsIdx = Input(UInt(log2Up(IssQueSize).W))
+    val isFirstIssue = Input(Bool())
   })
 
   val s0_uop = io.in.bits.uop
@@ -46,6 +47,7 @@ class LoadUnit_S0 extends XSModule {
   io.dtlbReq.bits.cmd := TlbCmd.read
   io.dtlbReq.bits.roqIdx := s0_uop.roqIdx
   io.dtlbReq.bits.debug.pc := s0_uop.cf.pc
+  io.dtlbReq.bits.debug.isFirstIssue := io.isFirstIssue
 
   // query DCache
   io.dcacheReq.valid := io.in.valid
@@ -262,6 +264,7 @@ class LoadUnit extends XSModule with HasLoadHelper {
     val flush = Input(Bool())
     val tlbFeedback = ValidIO(new TlbFeedback)
     val rsIdx = Input(UInt(log2Up(IssQueSize).W))
+    val isFirstIssue = Input(Bool())
     val dcache = new DCacheLoadIO
     val dtlb = new TlbRequestIO()
     val sbuffer = new LoadForwardQueryIO
@@ -277,6 +280,7 @@ class LoadUnit extends XSModule with HasLoadHelper {
   load_s0.io.dtlbReq <> io.dtlb.req
   load_s0.io.dcacheReq <> io.dcache.req
   load_s0.io.rsIdx := io.rsIdx
+  load_s0.io.isFirstIssue := io.isFirstIssue
 
   PipelineConnect(load_s0.io.out, load_s1.io.in, true.B, load_s0.io.out.bits.uop.roqIdx.needFlush(io.redirect, io.flush))
 

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -13,6 +13,7 @@ class StoreUnit_S0 extends XSModule {
   val io = IO(new Bundle() {
     val in = Flipped(Decoupled(new ExuInput))
     val rsIdx = Input(UInt(log2Up(IssQueSize).W))
+    val isFirstIssue = Input(Bool())
     val out = Decoupled(new LsPipelineBundle)
     val dtlbReq = DecoupledIO(new TlbReq)
   })
@@ -32,6 +33,7 @@ class StoreUnit_S0 extends XSModule {
   io.dtlbReq.bits.cmd := TlbCmd.write
   io.dtlbReq.bits.roqIdx := io.in.bits.uop.roqIdx
   io.dtlbReq.bits.debug.pc := io.in.bits.uop.cf.pc
+  io.dtlbReq.bits.debug.isFirstIssue := io.isFirstIssue
 
   io.out.bits := DontCare
   io.out.bits.vaddr := saddr
@@ -142,6 +144,7 @@ class StoreUnit extends XSModule {
     val tlbFeedback = ValidIO(new TlbFeedback)
     val dtlb = new TlbRequestIO()
     val rsIdx = Input(UInt(log2Up(IssQueSize).W))
+    val isFirstIssue = Input(Bool())
     val lsq = ValidIO(new LsPipelineBundle)
     val stout = DecoupledIO(new ExuOutput) // writeback store
   })
@@ -154,6 +157,7 @@ class StoreUnit extends XSModule {
   store_s0.io.in <> io.stin
   store_s0.io.dtlbReq <> io.dtlb.req
   store_s0.io.rsIdx := io.rsIdx
+  store_s0.io.isFirstIssue := io.isFirstIssue
 
   PipelineConnect(store_s0.io.out, store_s1.io.in, true.B, store_s0.io.out.bits.uop.roqIdx.needFlush(io.redirect, io.flush))
 


### PR DESCRIPTION
just record the tlb result(access and miss) of first issue by adding
signal isFirstIssue (isFirstIssue = cntCountQueue(i) === 0.U)