### PR TITLE
btb: use single port sram to meet timing constraints

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -114,6 +114,7 @@ class PredictorAnswer extends XSBundle {
 
 class BpuMeta extends XSBundle with HasBPUParameter {
   val btbWriteWay = UInt(log2Up(BtbWays).W)
+  val btbHit = Bool()
   val bimCtr = UInt(2.W)
   val tageMeta = new TageMeta
   // for global history
@@ -123,6 +124,8 @@ class BpuMeta extends XSBundle with HasBPUParameter {
   val debug_tage_cycle = if (EnableBPUTimeRecord) UInt(64.W) else UInt(0.W)
 
   val predictor = if (BPUDebug) UInt(log2Up(4).W) else UInt(0.W) // Mark which component this prediction comes from {ubtb, btb, tage, loopPredictor}
+
+  val ubtbHit = if (BPUDebug) UInt(1.W) else UInt(0.W)
 
   val ubtbAns = new PredictorAnswer
   val btbAns = new PredictorAnswer
@@ -194,7 +197,7 @@ class FtqEntry extends XSBundle {
   val specCnt = Vec(PredictWidth, UInt(10.W))
   val metas = Vec(PredictWidth, new BpuMeta)
 
-  val cfiIsCall, cfiIsRet, cfiIsRVC = Bool()
+  val cfiIsCall, cfiIsRet, cfiIsJalr, cfiIsRVC = Bool()
   val rvc_mask = Vec(PredictWidth, Bool())
   val br_mask = Vec(PredictWidth, Bool())
   val cfiIndex = ValidUndirectioned(UInt(log2Up(PredictWidth).W))
@@ -214,7 +217,7 @@ class FtqEntry extends XSBundle {
     p"ftqPC: ${Hexadecimal(ftqPC)} lastPacketPC: ${Hexadecimal(lastPacketPC.bits)} hasLastPrev:$hasLastPrev " +
       p"rasSp:$rasSp specCnt:$specCnt brmask:${Binary(Cat(br_mask))} rvcmask:${Binary(Cat(rvc_mask))} " +
       p"valids:${Binary(valids.asUInt())} cfi valid: ${cfiIndex.valid} " +
-      p"cfi index: ${cfiIndex.bits} isCall:$cfiIsCall isRet:$cfiIsRet isRvc:$cfiIsRVC " +
+      p"cfi index: ${cfiIndex.bits} isCall:$cfiIsCall isRet:$cfiIsRet isJalr:$cfiIsJalr, isRvc:$cfiIsRVC " +
       p"mispred:${Binary(Cat(mispred))} target:${Hexadecimal(target)}\n"
   }
 

--- a/src/main/scala/xiangshan/backend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/backend/ftq/Ftq.scala
@@ -150,7 +150,7 @@ class Ftq extends XSModule with HasCircularQueuePtrHelper {
   // multi-write
   val update_target = Reg(Vec(FtqSize, UInt(VAddrBits.W)))
   val cfiIndex_vec = Reg(Vec(FtqSize, ValidUndirectioned(UInt(log2Up(PredictWidth).W))))
-  val cfiIsCall, cfiIsRet, cfiIsRVC = Reg(Vec(FtqSize, Bool()))
+  val cfiIsCall, cfiIsRet, cfiIsJalr, cfiIsRVC = Reg(Vec(FtqSize, Bool()))
   val mispredict_vec = Reg(Vec(FtqSize, Vec(PredictWidth, Bool())))
 
   val s_invalid :: s_valid :: s_commited :: Nil = Enum(3)
@@ -164,6 +164,7 @@ class Ftq extends XSModule with HasCircularQueuePtrHelper {
     cfiIndex_vec(enqIdx) := io.enq.bits.cfiIndex
     cfiIsCall(enqIdx) := io.enq.bits.cfiIsCall
     cfiIsRet(enqIdx) := io.enq.bits.cfiIsRet
+    cfiIsJalr(enqIdx) := io.enq.bits.cfiIsJalr
     cfiIsRVC(enqIdx) := io.enq.bits.cfiIsRVC
     mispredict_vec(enqIdx) := WireInit(VecInit(Seq.fill(PredictWidth)(false.B)))
     update_target(enqIdx) := io.enq.bits.target
@@ -183,6 +184,7 @@ class Ftq extends XSModule with HasCircularQueuePtrHelper {
         cfiIndex_vec(wbIdx).bits := offset
         cfiIsCall(wbIdx) := wb.bits.uop.cf.pd.isCall
         cfiIsRet(wbIdx) := wb.bits.uop.cf.pd.isRet
+        cfiIsJalr(wbIdx) := wb.bits.uop.cf.pd.isJalr
         cfiIsRVC(wbIdx) := wb.bits.uop.cf.pd.isRVC
       }
       when (offset === cfiIndex_vec(wbIdx).bits) {
@@ -246,6 +248,7 @@ class Ftq extends XSModule with HasCircularQueuePtrHelper {
   commitEntry.cfiIndex := RegNext(RegNext(cfiIndex_vec(headPtr.value)))
   commitEntry.cfiIsCall := RegNext(RegNext(cfiIsCall(headPtr.value)))
   commitEntry.cfiIsRet := RegNext(RegNext(cfiIsRet(headPtr.value)))
+  commitEntry.cfiIsJalr := RegNext(RegNext(cfiIsJalr(headPtr.value)))
   commitEntry.cfiIsRVC := RegNext(RegNext(cfiIsRVC(headPtr.value)))
   commitEntry.target := RegNext(RegNext(update_target(headPtr.value)))
 

--- a/src/main/scala/xiangshan/frontend/Btb.scala
+++ b/src/main/scala/xiangshan/frontend/Btb.scala
@@ -60,6 +60,7 @@ class BTB extends BasePredictor with BTBParams{
   }
   class BTBMeta extends Meta {
     val writeWay =  Vec(PredictWidth, UInt(log2Up(BtbWays).W))
+    val hits = Vec(PredictWidth, Bool())
   }
   class BTBFromOthers extends FromOthers {}
 
@@ -76,10 +77,10 @@ class BTB extends BasePredictor with BTBParams{
   val if2_pc = RegEnable(if1_packetAlignedPC, io.pc.valid)
 
   // layout: way 0 bank 0, way 0 bank 1, ..., way 0 bank BtbBanks-1, way 1 bank 0, ..., way 1 bank BtbBanks-1
-  val data = Module(new SRAMTemplate(new BtbDataEntry, set = nRows, way=BtbWays*BtbBanks, shouldReset = true, holdRead = true))
-  val meta = Module(new SRAMTemplate(new BtbMetaEntry, set = nRows, way=BtbWays*BtbBanks, shouldReset = true, holdRead = true))
+  val data = Module(new SRAMTemplate(new BtbDataEntry, set = nRows, way=BtbWays*BtbBanks, shouldReset = true, holdRead = true, singlePort = true))
+  val meta = Module(new SRAMTemplate(new BtbMetaEntry, set = nRows, way=BtbWays*BtbBanks, shouldReset = true, holdRead = true, singlePort = true))
 
-  val edata = Module(new SRAMTemplate(UInt(VAddrBits.W), set = extendedNRows, shouldReset = true, holdRead = true))
+  val edata = Module(new SRAMTemplate(UInt(VAddrBits.W), set = extendedNRows, shouldReset = true, holdRead = true, singlePort = true))
 
   val if1_mask = io.inMask
   val if2_mask = RegEnable(if1_mask, io.pc.valid)
@@ -157,6 +158,7 @@ class BTB extends BasePredictor with BTBParams{
     io.resp.isBrs(b) := meta_entry.isBr
     io.resp.isRVC(b) := meta_entry.isRVC
     io.meta.writeWay(b) := writeWay(b)
+    io.meta.hits(b) := if2_bankHits(b)
     // io.meta.hitJal(b)   := if2_bankHits(b) && meta_entry.btbType === BTBtype.J
   }
 
@@ -186,12 +188,15 @@ class BTB extends BasePredictor with BTBParams{
   val updateRow = btbAddr.getBankIdx(cfi_pc)
   val updateIsBr = u.br_mask(u.cfiIndex.bits)
   val updateTaken = u.cfiIndex.valid && u.valids(u.cfiIndex.bits)
+  val updateIndirectMisPred = u.mispred(u.cfiIndex.bits) && u.cfiIsJalr
   // TODO: remove isRVC
   val metaWrite = BtbMetaEntry(btbAddr.getTag(cfi_pc), updateIsBr, u.cfiIsRVC)
   val dataWrite = BtbDataEntry(new_lower, new_extended)
   
-
-  val updateValid = do_update.valid && updateTaken
+  val cfi_hit = u.metas(u.cfiIndex.bits).btbHit
+  // for brs and jals, prediction is right once hit, so we only update on not hit or jalr mispreds
+  val updateValid = do_update.valid && updateTaken && (!cfi_hit || updateIndirectMisPred)
+  in_ready := !updateValid
   // Update btb
   require(isPow2(BtbBanks))
   // this is one hot, since each fetch bundle has at most 1 taken instruction
@@ -200,10 +205,34 @@ class BTB extends BasePredictor with BTBParams{
   data.io.w.apply(updateValid, dataWrite, updateRow, updateWayMask)
   edata.io.w.apply(updateValid && new_extended, u.target, updateRow, "b1".U)
 
-  val alloc_conflict =
-    VecInit((0 until BtbBanks).map(i =>
-      if2_metaRead(allocWays(i))(i).valid && !if2_bankHits(i) && if2_mask(i)))
-  XSPerf("btb_alloc_conflict", PopCount(alloc_conflict))
+  
+  if (!env.FPGAPlatform) {
+    val alloc_conflict =
+      VecInit((0 until BtbBanks).map(i =>
+        if2_metaRead(allocWays(i))(i).valid && !if2_bankHits(i) && if2_mask(i)))
+    XSPerf("btb_alloc_conflict", PopCount(alloc_conflict))
+    XSPerf("btb_update_req", updateValid)
+    XSPerf("ebtb_update_req", updateValid && new_extended)
+    XSPerf("btb_wr_conflict", updateValid && io.pc.valid)
+    XSPerf("ebtb_wr_conflict", updateValid && new_extended && io.pc.valid)
+    XSPerf("btb_update_indirect_mispred", updateValid && updateIndirectMisPred)
+    def btb_perf(hit_cond: Bool)(str: String, cfi_cond: PreDecodeInfoForDebug => UInt): Unit = {
+      XSPerf(str, PopCount((u.takens zip u.valids zip u.metas zip u.pd) map {
+          case (((t, v), m), pd)  => t && v && (m.btbHit.asBool === hit_cond) && cfi_cond(pd).asBool && do_update.valid && updateTaken}))
+    }
+    val btb_miss_perf = btb_perf(false.B)(_,_)
+    val btb_hit_perf = btb_perf(true.B)(_,_)
+    btb_hit_perf("btb_commit_hits", pd => !pd.notCFI)
+    btb_hit_perf("btb_commit_hit_brs", pd => pd.isBr)
+    btb_hit_perf("btb_commit_hit_jals", pd => pd.isJal)
+    btb_hit_perf("btb_commit_hit_jalrs", pd => pd.isJalr)
+    btb_hit_perf("btb_commit_hit_rets", pd => pd.isRet)
+    btb_miss_perf("btb_commit_misses", pd => !pd.notCFI)
+    btb_miss_perf("btb_commit_miss_brs", pd => pd.isBr)
+    btb_miss_perf("btb_commit_miss_jals", pd => pd.isJal)
+    btb_miss_perf("btb_commit_miss_jalrs", pd => pd.isJalr)
+    btb_miss_perf("btb_commit_miss_rets", pd => pd.isRet)
+  }
 
   if (BPUDebug && debug) {
     val debug_verbose = true

--- a/src/main/scala/xiangshan/frontend/uBTB.scala
+++ b/src/main/scala/xiangshan/frontend/uBTB.scala
@@ -228,6 +228,15 @@ class MicroBTB extends BasePredictor
         banks(b).update_write_data.bits := update_write_datas(b)
         banks(b).update_taken := update_takens(b)
     }
+
+    if (!env.FPGAPlatform) {
+        XSPerf("ubtb_commit_hits",
+            PopCount((u.takens zip u.valids zip u.metas zip u.pd) map {
+                case (((t, v), m), pd)  => t && v && m.ubtbHit.asBool && !pd.notCFI && update_valid}))
+        XSPerf("ubtb_commit_misses",
+            PopCount((u.takens zip u.valids zip u.metas zip u.pd) map {
+                case (((t, v), m), pd)  => t && v && !m.ubtbHit.asBool && !pd.notCFI && update_valid}))
+    }
     
     if (BPUDebug && debug) {
         val update_pcs  = VecInit((0 until PredictWidth).map(i => update_packet_pc + (i << instOffsetBits).U))


### PR DESCRIPTION
* add perf counters for btb and ubtb
* update btb only on not hit or jalr mispredicts to reduce write stalls