### PR TITLE
LogUtils: remove trait 'HasXSLog'

### DIFF
--- a/src/main/scala/device/AXI4SlaveModule.scala
+++ b/src/main/scala/device/AXI4SlaveModule.scala
@@ -6,7 +6,6 @@ import utils._
 import freechips.rocketchip.diplomacy.{AddressSet, LazyModule, LazyModuleImp, RegionType, TransferSizes}
 import chipsalliance.rocketchip.config.Parameters
 import freechips.rocketchip.amba.axi4.{AXI4Parameters, AXI4SlaveNode, AXI4SlaveParameters, AXI4SlavePortParameters}
-import xiangshan.HasXSLog
 
 abstract class AXI4SlaveModule[T <: Data]
 (
@@ -34,7 +33,7 @@ abstract class AXI4SlaveModule[T <: Data]
 }
 
 class AXI4SlaveModuleImp[T<:Data](outer: AXI4SlaveModule[T])
-  extends LazyModuleImp(outer) with HasXSLog
+  extends LazyModuleImp(outer)
 {
   val io = IO(new Bundle {
     val extra = if(outer._extra == null) None else Some(outer._extra.cloneType)

--- a/src/main/scala/device/TLTimer.scala
+++ b/src/main/scala/device/TLTimer.scala
@@ -7,7 +7,6 @@ import chipsalliance.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper.RegField
 import utils.{HasTLDump, XSDebug}
-import xiangshan.HasXSLog
 
 class TLTimer(address: Seq[AddressSet], sim: Boolean)(implicit p: Parameters) extends LazyModule {
 
@@ -15,7 +14,7 @@ class TLTimer(address: Seq[AddressSet], sim: Boolean)(implicit p: Parameters) ex
   val node = TLRegisterNode(address, device, beatBytes = 8)
   val NumCores = top.Parameters.get.socParameters.NumCores
 
-  lazy val module = new LazyModuleImp(this) with HasXSLog with HasTLDump{
+  lazy val module = new LazyModuleImp(this) with HasTLDump {
     val io = IO(new Bundle() {
       val mtip = Output(Vec(NumCores, Bool()))
       val msip = Output(Vec(NumCores, Bool()))

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.diplomacy.{AddressSet, LazyModule, LazyModuleImp}
 import freechips.rocketchip.tilelink.{BankBinder, TLBuffer, TLBundleParameters, TLCacheCork, TLClientNode, TLFilter, TLFuzzer, TLIdentityNode, TLToAXI4, TLWidthWidget, TLXbar}
 import utils.{DataDontCareNode, DebugIdentityNode}
 import utils.XSInfo
-import xiangshan.{DifftestBundle, HasXSLog, HasXSParameter, XSBundle, XSCore}
+import xiangshan.{DifftestBundle, HasXSParameter, XSBundle, XSCore}
 import xiangshan.cache.prefetch._
 import sifive.blocks.inclusivecache.{CacheParameters, InclusiveCache, InclusiveCacheMicroParameters}
 import freechips.rocketchip.diplomacy.{AddressSet, LazyModule, LazyModuleImp}

--- a/src/main/scala/utils/DataDontCareNode.scala
+++ b/src/main/scala/utils/DataDontCareNode.scala
@@ -5,7 +5,6 @@ import chipsalliance.rocketchip.config.Parameters
 import chisel3.util.DecoupledIO
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import freechips.rocketchip.tilelink.{TLBundle, TLClientNode, TLIdentityNode, TLMasterParameters, TLMasterPortParameters}
-import xiangshan.HasXSLog
 
 class DataDontCareNode(a: Boolean = false, b: Boolean = false, c: Boolean = false, d: Boolean = false)(implicit p: Parameters) extends LazyModule  {
 
@@ -17,7 +16,7 @@ class DataDontCareNode(a: Boolean = false, b: Boolean = false, c: Boolean = fals
     )
   )))
 
-  lazy val module = new LazyModuleImp(this) with HasXSLog with HasTLDump{
+  lazy val module = new LazyModuleImp(this) with HasTLDump{
     val (out, _) = node.out(0)
     val (in, _) = node.in(0)
 

--- a/src/main/scala/utils/DebugIdentityNode.scala
+++ b/src/main/scala/utils/DebugIdentityNode.scala
@@ -5,7 +5,6 @@ import chipsalliance.rocketchip.config.Parameters
 import chisel3.util.DecoupledIO
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import freechips.rocketchip.tilelink.{TLBundle, TLClientNode, TLIdentityNode, TLMasterParameters, TLMasterPortParameters}
-import xiangshan.HasXSLog
 
 class DebugIdentityNode()(implicit p: Parameters) extends LazyModule  {
 
@@ -17,7 +16,7 @@ class DebugIdentityNode()(implicit p: Parameters) extends LazyModule  {
     )
   )))
 
-  lazy val module = new LazyModuleImp(this) with HasXSLog with HasTLDump{
+  lazy val module = new LazyModuleImp(this) with HasTLDump{
     val (out, _) = node.out(0)
     val (in, _) = node.in(0)
 

--- a/src/main/scala/utils/PerfCounterUtils.scala
+++ b/src/main/scala/utils/PerfCounterUtils.scala
@@ -5,7 +5,7 @@ import top.Parameters
 import xiangshan.HasXSParameter
 
 object XSPerfAccumulate extends HasXSParameter {
-  def apply(perfName: String, perfCnt: UInt)(implicit name: String) = {
+  def apply(perfName: String, perfCnt: UInt) = {
     val env = Parameters.get.envParameters
     if (env.EnablePerfDebug && !env.FPGAPlatform) {
       val logTimestamp = WireInit(0.U(64.W))
@@ -29,7 +29,7 @@ object XSPerfAccumulate extends HasXSParameter {
 object XSPerfHistogram extends HasXSParameter {
   // instead of simply accumulating counters
   // this function draws a histogram
-  def apply(perfName: String, perfCnt: UInt, enable: Bool, start: Int, stop: Int, step: Int)(implicit name: String) = {
+  def apply(perfName: String, perfCnt: UInt, enable: Bool, start: Int, stop: Int, step: Int) = {
     val env = Parameters.get.envParameters
     if (env.EnablePerfDebug && !env.FPGAPlatform) {
       val logTimestamp = WireInit(0.U(64.W))
@@ -71,7 +71,7 @@ object XSPerfHistogram extends HasXSParameter {
   }
 }
 object XSPerfMax extends HasXSParameter {
-  def apply(perfName: String, perfCnt: UInt, enable: Bool)(implicit name: String) = {
+  def apply(perfName: String, perfCnt: UInt, enable: Bool) = {
     val env = Parameters.get.envParameters
     if (env.EnablePerfDebug && !env.FPGAPlatform) {
       val logTimestamp = WireInit(0.U(64.W))
@@ -93,7 +93,7 @@ object XSPerfMax extends HasXSParameter {
 }
 
 object QueuePerf extends HasXSParameter {
-  def apply(size: Int, utilization: UInt, full: UInt)(implicit name: String) = {
+  def apply(size: Int, utilization: UInt, full: UInt) = {
     XSPerfAccumulate("utilization", utilization)
     XSPerfAccumulate("full", full)
     val exHalf = utilization > (size/2).U

--- a/src/main/scala/utils/Replacement.scala
+++ b/src/main/scala/utils/Replacement.scala
@@ -8,7 +8,7 @@ import chisel3.util._
 import chisel3.util.random.LFSR
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property.cover
-import xiangshan.{HasXSLog, XSCoreParameters}
+import xiangshan.{XSCoreParameters}
 
 abstract class ReplacementPolicy {
   def nBits: Int

--- a/src/main/scala/utils/TLDump.scala
+++ b/src/main/scala/utils/TLDump.scala
@@ -5,10 +5,8 @@ import chisel3.util._
 import freechips.rocketchip.tilelink.TLMessages._
 import freechips.rocketchip.tilelink.TLPermissions._
 import freechips.rocketchip.tilelink.{TLBundle, TLBundleA, TLBundleB, TLBundleC, TLBundleD, TLBundleE, TLChannel}
-import xiangshan.HasXSLog
 
 trait HasTLDump {
-  this: HasXSLog =>
 
   implicit class TLDump(channel: TLChannel) {
     def dump = channel match {

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -280,15 +280,9 @@ trait HasXSParameter {
   )
 }
 
-trait HasXSLog {
-  this: RawModule =>
-  implicit val moduleName: String = this.name
-}
-
 abstract class XSModule extends MultiIOModule
   with HasXSParameter
   with HasExceptionNO
-  with HasXSLog
   with HasFPUParameters {
   def io: Record
 }

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -47,7 +47,6 @@ class MemBlock(
 class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   with HasXSParameter
   with HasExceptionNO
-  with HasXSLog
   with HasFPUParameters
   with HasExeBlockHelper
   with HasFpLoadHelper

--- a/src/main/scala/xiangshan/cache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/DCacheWrapper.scala
@@ -127,7 +127,7 @@ class DCache()(implicit p: Parameters) extends LazyModule with HasDCacheParamete
 }
 
 
-class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParameters with HasXSLog {
+class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParameters {
 
   val io = IO(new DCacheIO)
 

--- a/src/main/scala/xiangshan/cache/ICacheMissQueue.scala
+++ b/src/main/scala/xiangshan/cache/ICacheMissQueue.scala
@@ -9,7 +9,6 @@ import chisel3.ExcitingUtils._
 
 abstract class ICacheMissQueueModule extends XSModule
   with HasICacheParameters 
-  with HasXSLog
 
 abstract class ICacheMissQueueBundle extends XSBundle
   with HasICacheParameters

--- a/src/main/scala/xiangshan/cache/InstrUncache.scala
+++ b/src/main/scala/xiangshan/cache/InstrUncache.scala
@@ -149,7 +149,6 @@ class InstrUncache()(implicit p: Parameters) extends LazyModule with HasICachePa
 class icacheUncacheImp(outer: InstrUncache)
   extends LazyModuleImp(outer)
     with HasICacheParameters
-    with HasXSLog
     with HasTLDump
 {
   val io = IO(new icacheUncacheIO)

--- a/src/main/scala/xiangshan/cache/L1plusCache.scala
+++ b/src/main/scala/xiangshan/cache/L1plusCache.scala
@@ -3,7 +3,6 @@ package xiangshan.cache
 import chisel3._
 import chisel3.util._
 import utils.{Code, ReplacementPolicy, HasTLDump, XSDebug, SRAMTemplate, XSPerfAccumulate}
-import xiangshan.{HasXSLog}
 import system.L1CacheErrorInfo
 
 import chipsalliance.rocketchip.config.Parameters
@@ -367,7 +366,7 @@ class L1plusCache()(implicit p: Parameters) extends LazyModule with HasL1plusCac
 }
 
 
-class L1plusCacheImp(outer: L1plusCache) extends LazyModuleImp(outer) with HasL1plusCacheParameters with HasXSLog {
+class L1plusCacheImp(outer: L1plusCache) extends LazyModuleImp(outer) with HasL1plusCacheParameters {
 
   val io = IO(Flipped(new L1plusCacheIO))
 

--- a/src/main/scala/xiangshan/cache/PTW.scala
+++ b/src/main/scala/xiangshan/cache/PTW.scala
@@ -97,7 +97,7 @@ trait HasPtwConst extends HasTlbConst with MemoryOpConstants{
 
 abstract class PtwBundle extends XSBundle with HasPtwConst
 abstract class PtwModule(outer: PTW) extends LazyModuleImp(outer)
-  with HasXSParameter with HasXSLog with HasPtwConst
+  with HasXSParameter with HasPtwConst
 
 class PteBundle extends PtwBundle{
   val reserved  = UInt(pteResLen.W)
@@ -808,7 +808,7 @@ class PTWImp(outer: PTW) extends PtwModule(outer) {
   XSDebug(RegNext(sfence.valid), p"[sfence] spv:${Binary(spv)}\n")
 }
 
-class PTWRepeater extends XSModule with HasXSParameter with HasXSLog with HasPtwConst {
+class PTWRepeater extends XSModule with HasXSParameter with HasPtwConst {
   val io = IO(new Bundle {
     val tlb = Flipped(new TlbPtwIO)
     val ptw = new TlbPtwIO

--- a/src/main/scala/xiangshan/cache/Uncache.scala
+++ b/src/main/scala/xiangshan/cache/Uncache.scala
@@ -6,7 +6,7 @@ import utils.{HasTLDump, PriorityMuxWithFlag, XSDebug}
 import chipsalliance.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.{IdRange, LazyModule, LazyModuleImp, TransferSizes}
 import freechips.rocketchip.tilelink.{TLArbiter, TLBundleA, TLBundleD, TLClientNode, TLEdgeOut, TLMasterParameters, TLMasterPortParameters}
-import xiangshan.{HasXSLog, MicroOp, Redirect}
+import xiangshan.{MicroOp, Redirect}
 
 // One miss entry deals with one mmio request
 class MMIOEntry(edge: TLEdgeOut) extends DCacheModule
@@ -142,7 +142,6 @@ class Uncache()(implicit p: Parameters) extends LazyModule with HasDCacheParamet
 class UncacheImp(outer: Uncache)
   extends LazyModuleImp(outer)
     with HasDCacheParameters
-    with HasXSLog
     with HasTLDump
 {
   val io = IO(new UncacheIO)

--- a/src/main/scala/xiangshan/cache/prefetch/L2Prefetcher.scala
+++ b/src/main/scala/xiangshan/cache/prefetch/L2Prefetcher.scala
@@ -61,7 +61,7 @@ class L2PrefetcherIO extends XSBundle with HasPrefetchParameters {
 }
 
 // prefetch DCache lines in L2 using StreamPrefetch
-class L2PrefetcherImp(outer: L2Prefetcher) extends LazyModuleImp(outer) with HasPrefetchParameters with HasXSLog {  
+class L2PrefetcherImp(outer: L2Prefetcher) extends LazyModuleImp(outer) with HasPrefetchParameters {  
   val io = IO(new L2PrefetcherIO)
 
   val (bus, edge) = outer.clientNode.out.head

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -23,7 +23,6 @@ class FrontendImp (outer: Frontend) extends LazyModuleImp(outer)
   with HasL1plusCacheParameters 
   with HasXSParameter
   with HasExceptionNO
-  with HasXSLog
 {
   val io = IO(new Bundle() {
     val icacheMemAcq = DecoupledIO(new L1plusCacheReq)

--- a/src/test/scala/cache/L1DTest/L1DTest.scala
+++ b/src/test/scala/cache/L1DTest/L1DTest.scala
@@ -14,7 +14,7 @@ import freechips.rocketchip.tilelink.{TLBuffer, TLCacheCork, TLToAXI4, TLXbar}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import utils.{DebugIdentityNode, HoldUnless, XSDebug}
-import xiangshan.{EnviromentParameters, HasXSLog}
+import xiangshan.EnviromentParameters
 import xiangshan.cache.{DCache, DCacheLineReq, DCacheToLsuIO, DCacheWordReq, MemoryOpConstants}
 import xiangshan.testutils.AddSinks
 import xstransforms.PrintModuleName
@@ -38,7 +38,7 @@ class L1DTestTop()(implicit p: Parameters) extends LazyModule {
   val c_buffer = TLBuffer(a = BufferParams.none, b = BufferParams.none, c = BufferParams.pipe, d = BufferParams.none, e = BufferParams.none)
   slave.node := dcache_outer.node := c_buffer := dcache.clientNode
 
-  lazy val module = new LazyModuleImp(this) with HasXSLog {
+  lazy val module = new LazyModuleImp(this) {
     val io = IO(new L1DTestTopIO())
     dcache.module.io.lsu <> io.dcacheIO
     slave.module.io <> io.slaveIO

--- a/src/test/scala/cache/L1plusCacheTest.scala
+++ b/src/test/scala/cache/L1plusCacheTest.scala
@@ -18,7 +18,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import sifive.blocks.inclusivecache.{CacheParameters, InclusiveCache, InclusiveCacheMicroParameters}
 import utils.{DebugIdentityNode, HoldUnless, XSDebug}
-import xiangshan.{HasXSLog, MicroOp}
+import xiangshan.MicroOp
 import xiangshan.cache.{DCache, DCacheLineIO, L1plusCache, L1plusCacheIO, MemoryOpConstants}
 import xiangshan.testutils.AddSinks
 import xstransforms.PrintModuleName
@@ -70,7 +70,7 @@ class L1plusTestTop()(implicit p: Parameters) extends LazyModule{
     TLCacheCork() :=
     l2.node
 
-  lazy val module = new LazyModuleImp(this) with HasXSLog {
+  lazy val module = new LazyModuleImp(this) {
 
     val io = IO(Flipped(new L1plusTestTopIO))
 

--- a/src/test/scala/cache/L2CacheNonInclusiveGetTest.scala
+++ b/src/test/scala/cache/L2CacheNonInclusiveGetTest.scala
@@ -18,7 +18,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import sifive.blocks.inclusivecache.{CacheParameters, InclusiveCache, InclusiveCacheControlParameters, InclusiveCacheMicroParameters}
 import utils.{DebugIdentityNode, HoldUnless, XSDebug}
-import xiangshan.{HasXSLog, MicroOp}
+import xiangshan.MicroOp
 import xiangshan.cache.{DCache, DCacheLineIO, DCacheWordIO, L1plusCache, L1plusCacheIO, MemoryOpConstants, Uncache}
 import xiangshan.testutils.AddSinks
 import xstransforms.PrintModuleName
@@ -75,7 +75,7 @@ class L2NonInclusiveGetTestTop()(implicit p: Parameters) extends LazyModule {
   // connect uncache access to l2 control node
   l2.ctlnode.get := DebugIdentityNode() := uncache.clientNode
 
-  lazy val module = new LazyModuleImp(this) with HasXSLog {
+  lazy val module = new LazyModuleImp(this) {
 
     val io = IO(Flipped(new L2NonInclusiveGetTestTopIO))
 

--- a/src/test/scala/cache/L2CacheTest.scala
+++ b/src/test/scala/cache/L2CacheTest.scala
@@ -18,7 +18,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import sifive.blocks.inclusivecache.{CacheParameters, InclusiveCache, InclusiveCacheMicroParameters}
 import utils.{DebugIdentityNode, HoldUnless, XSDebug}
-import xiangshan.HasXSLog
 import xiangshan.cache.{DCache, DCacheLineReq, DCacheWordReq, MemoryOpConstants}
 import xiangshan.testutils.AddSinks
 import xstransforms.PrintModuleName
@@ -123,7 +122,7 @@ class L2TestTop()(implicit p: Parameters) extends LazyModule{
     TLCacheCork() :=
     l3.node
 
-  lazy val module = new LazyModuleImp(this) with HasXSLog {
+  lazy val module = new LazyModuleImp(this) {
 
     val io = IO(new L2TestTopIO)
 

--- a/src/test/scala/cache/TLCTest/TLCTest.scala
+++ b/src/test/scala/cache/TLCTest/TLCTest.scala
@@ -15,7 +15,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import sifive.blocks.inclusivecache.{CacheParameters, InclusiveCache, InclusiveCacheMicroParameters}
 import utils.{DebugIdentityNode, XSDebug}
-import xiangshan.HasXSLog
 import xiangshan.testutils.AddSinks
 import xstransforms.PrintModuleName
 
@@ -86,7 +85,7 @@ class TLCCacheTestTop()(implicit p: Parameters) extends LazyModule {
   val slave = LazyModule(new TLCSlaveMMIO())
   slave.node := l3_ident.node := TLBuffer() := l2_outer_ident.node := l2.node
 
-  lazy val module = new LazyModuleImp(this) with HasXSLog {
+  lazy val module = new LazyModuleImp(this) {
 
     val io = IO(new TLCCacheTestTopIO)
 

--- a/src/test/scala/cache/TLCTest/TLMasterMMIO.scala
+++ b/src/test/scala/cache/TLCTest/TLMasterMMIO.scala
@@ -5,7 +5,6 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.diplomacy.{IdRange, LazyModule, LazyModuleImp, TransferSizes}
 import freechips.rocketchip.tilelink.{TLClientNode, TLMasterParameters, TLMasterPortParameters}
-import xiangshan.HasXSLog
 import xiangshan.cache.{DCacheBundle, HasDCacheParameters}
 
 class TLCFakeBundle extends DCacheBundle
@@ -82,7 +81,7 @@ class TLCMasterMMIO()(implicit p: Parameters) extends LazyModule
   val node = TLClientNode(Seq(clientParameters))
 
 
-  lazy val module = new LazyModuleImp(this) with HasXSLog {
+  lazy val module = new LazyModuleImp(this) {
 
     val (bus,edge) = node.out.head
 

--- a/src/test/scala/cache/TLCTest/TLSlaveMMIO.scala
+++ b/src/test/scala/cache/TLCTest/TLSlaveMMIO.scala
@@ -5,7 +5,6 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.diplomacy.{AddressSet, LazyModule, LazyModuleImp, RegionType, SimpleDevice, TransferSizes}
 import freechips.rocketchip.tilelink.{TLClientNode, TLManagerNode, TLSlaveParameters, TLSlavePortParameters}
-import xiangshan.HasXSLog
 import xiangshan.cache.{DCacheBundle, HasDCacheParameters}
  
 class TLCTestSlaveMMIO extends DCacheBundle
@@ -43,7 +42,7 @@ class TLCSlaveMMIO()(implicit p: Parameters) extends LazyModule
   )))
 
 
-  lazy val module = new LazyModuleImp(this) with HasXSLog {
+  lazy val module = new LazyModuleImp(this) {
 
     val (bus,edge) = node.in.head
 

--- a/src/test/scala/cache/TLCTest/TLULMMIO.scala
+++ b/src/test/scala/cache/TLCTest/TLULMMIO.scala
@@ -5,7 +5,6 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.diplomacy.{AddressSet, LazyModule, LazyModuleImp, RegionType, SimpleDevice, TransferSizes}
 import freechips.rocketchip.tilelink.{TLAdapterNode, TLClientNode, TLManagerNode, TLSlaveParameters, TLSlavePortParameters}
-import xiangshan.HasXSLog
 import xiangshan.cache.{DCacheBundle, HasDCacheParameters}
 
 class TLULMMIO extends DCacheBundle {
@@ -24,7 +23,7 @@ class TLCSnoopMMIONode()(implicit p: Parameters) extends LazyModule
 
   val node = TLAdapterNode()
 
-  lazy val module = new LazyModuleImp(this) with HasXSLog {
+  lazy val module = new LazyModuleImp(this) {
     val io = IO(new TLULMMIO)
 
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>

--- a/src/test/scala/cache/UnalignedGetTest.scala
+++ b/src/test/scala/cache/UnalignedGetTest.scala
@@ -17,7 +17,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 import sifive.blocks.inclusivecache.{CacheParameters, InclusiveCache, InclusiveCacheMicroParameters, InclusiveCacheControlParameters}
 import utils.{DebugIdentityNode, HoldUnless, XSDebug}
-import xiangshan.{HasXSLog, XSBundle, HasXSParameter}
+import xiangshan.{XSBundle, HasXSParameter}
 import xiangshan.cache.{DCache, Uncache, DCacheLineReq, DCacheWordReq, MemoryOpConstants}
 import xiangshan.testutils.AddSinks
 import xstransforms.PrintModuleName
@@ -60,7 +60,6 @@ class GetGenerator()(implicit p: Parameters) extends LazyModule with HasXSParame
 
 class GetGeneratorImp(outer: GetGenerator) extends LazyModuleImp(outer)
   with HasXSParameter
-  with HasXSLog
 {
 
   val io = IO(Flipped(new GetGeneratorIO))
@@ -235,7 +234,7 @@ class UnalignedGetTestTop()(implicit p: Parameters) extends LazyModule{
   // connect uncache access to l2 control node
   l2.ctlnode.get := DebugIdentityNode() := uncache.clientNode
 
-  lazy val module = new LazyModuleImp(this) with HasXSLog {
+  lazy val module = new LazyModuleImp(this) {
 
     val io = IO(new UnalignedGetTestTopIO)
 


### PR DESCRIPTION
Because we use '%m' to print instance name, trait 'HasXSLog' and implicit val 'moduleName' should be removed.