### PR TITLE
ICache: set holdRead to true for meta and data SRAMs

### DIFF
--- a/src/main/scala/xiangshan/cache/ICache.scala
+++ b/src/main/scala/xiangshan/cache/ICache.scala
@@ -179,6 +179,7 @@ class ICacheMetaArray extends ICacheArray
     set=nSets,
     way=nWays,
     shouldReset = true,
+    holdRead = true,
     singlePort = true
   ))
 
@@ -219,6 +220,7 @@ class ICacheDataArray extends ICacheArray
     UInt(dataEntryBits.W),
     set=nSets,
     way = 1,
+    holdRead = true,
     singlePort = true
   ))}}
 


### PR DESCRIPTION
SyncReadMem generates the verilog behavior model whose output rdata is always
mem(RegNext(raddr)). Accidentally, ICache will not change meta and data
SRAMs' raddr if the second pipeline stage is stalled (and ren is false).
Thus, the SRAMs seem to have the holdRead property.
Obviously, it will cause errors on real SRAMs. We set holdRead to true to fix the bug.