### PR TITLE
Makefile: enable SRAM randomization for verilator simulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,15 @@ SIM_TOP_V = $(BUILD_DIR)/$(SIM_TOP).v
 $(SIM_TOP_V): $(SCALA_FILE) $(TEST_FILE)
 	mkdir -p $(@D)
 	date -R
-	mill XiangShan.test.runMain $(SIMTOP) -X verilog -td $(@D) --full-stacktrace --output-file $(@F) $(SIM_ARGS)
+	mill XiangShan.test.runMain $(SIMTOP) -td $(@D) --full-stacktrace --output-file $(@F) --infer-rw --repl-seq-mem -c:$(SIMTOP):-o:$(@D)/$(@F).conf $(SIM_ARGS)
+	$(MEM_GEN) $(@D)/$(@F).conf --output_file $(@D)/$(@F).sram.v
+	@git log -n 1 >> .__head__
+	@git diff >> .__diff__
+	@sed -i 's/^/\/\// ' .__head__
+	@sed -i 's/^/\/\//' .__diff__
+	@cat .__head__ .__diff__ $@ $(@D)/$(@F).sram.v > .__out__
+	@mv .__out__ $@
+	@rm .__head__ .__diff__
 	sed -i '/module XSSimTop/,/endmodule/d' $(SIM_TOP_V)
 	sed -i -e 's/$$fatal/xs_assert(`__LINE__)/g' $(SIM_TOP_V)
 	date -R
@@ -114,14 +122,17 @@ endif
 
 # --trace
 VERILATOR_FLAGS = --top-module $(EMU_TOP) \
-  +define+VERILATOR=1 \
-  +define+PRINTF_COND=1 \
-  +define+RANDOMIZE_REG_INIT \
-  +define+RANDOMIZE_MEM_INIT \
-  $(VEXTRA_FLAGS) \
-  --assert \
-  --stats-vars \
-  --output-split 30000 \
+  +define+VERILATOR=1                     \
+  +define+PRINTF_COND=1                   \
+  +define+RANDOMIZE_REG_INIT              \
+  +define+RANDOMIZE_MEM_INIT              \
+  +define+RANDOMIZE_GARBAGE_ASSIGN        \
+  +define+RANDOMIZE_DELAY=0               \
+  $(VEXTRA_FLAGS)                         \
+  -Wno-STMTDLY -Wno-WIDTH                 \
+  --assert                                \
+  --stats-vars                            \
+  --output-split 30000                    \
   --output-split-cfuncs 30000
 
 EMU_MK := $(BUILD_DIR)/emu-compile/V$(EMU_TOP).mk

--- a/src/main/scala/xiangshan/cache/ICache.scala
+++ b/src/main/scala/xiangshan/cache/ICache.scala
@@ -179,6 +179,7 @@ class ICacheMetaArray extends ICacheArray
     set=nSets,
     way=nWays,
     shouldReset = true,
+    holdRead = true,
     singlePort = true
   ))
 
@@ -219,6 +220,7 @@ class ICacheDataArray extends ICacheArray
     UInt(dataEntryBits.W),
     set=nSets,
     way = 1,
+    holdRead = true,
     singlePort = true
   ))}}
 


### PR DESCRIPTION
Previously we don't use the --infer-rw and --repl-seq-mem flags for simulation verilog.
However, the SyncReadMem fails to generate random read data when ren is not set.
In this commit, SyncReadMem is changed to blackboxes and generated by the vlsi_mem_gen script.
RANDOMIZE_GARBAGE_ASSIGN flag is defined to enable randomization.

Merge this after #736 is merged. 