### PR TITLE
CSR: add self-defined maskmip register to disable external interrupts

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
@@ -58,6 +58,7 @@ trait HasCSRConst {
   val Srnctl        = 0x5C4
 
   val Sdsid         = 0x9C0
+  val Smaskmip      = 0x9C1
 
   // Machine Information Registers
   val Mvendorid     = 0xF11


### PR DESCRIPTION
We have not tested our PLIC implementation. In case of it doesn't work
as expected, we add a self-defined CSR to support disable external interrupts.