### PR TITLE
build.sc: bump chisel to v3.4.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ SIM_TOP_V = $(BUILD_DIR)/$(SIM_TOP).v
 $(SIM_TOP_V): $(SCALA_FILE) $(TEST_FILE)
 	mkdir -p $(@D)
 	date -R
-	mill XiangShan.test.runMain $(SIMTOP) -td $(@D) --full-stacktrace --output-file $(@F) --infer-rw --repl-seq-mem -c:$(SIMTOP):-o:$(@D)/$(@F).conf $(SIM_ARGS)
+	mill XiangShan.test.runMain $(SIMTOP) -X verilog -td $(@D) --full-stacktrace --output-file $(@F) --infer-rw --repl-seq-mem -c:$(SIMTOP):-o:$(@D)/$(@F).conf $(SIM_ARGS)
 	$(MEM_GEN) $(@D)/$(@F).conf --output_file $(@D)/$(@F).sram.v
 	@git log -n 1 >> .__head__
 	@git diff >> .__diff__

--- a/build.sc
+++ b/build.sc
@@ -29,7 +29,7 @@ trait CommonModule extends ScalaModule {
 }
 
 val chisel = Agg(
-  ivy"edu.berkeley.cs::chisel3:3.4.2"
+  ivy"edu.berkeley.cs::chisel3:3.4.3"
 )
 
 object `api-config-chipsalliance` extends CommonModule {


### PR DESCRIPTION
Bump chisel to v3.4.3 and re-add `-X verilog` parameter for chisel runs.
Our transform seems to have conflicts when `-X verilog` is not set.

This PR should fix the bug that 9527 is not replaced by %m.