### PR TITLE
Add dispatch and issue performance counters

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -303,6 +303,16 @@ class MicroOp(implicit p: Parameters) extends CfCtrl {
   val sqIdx = new SqPtr
   val diffTestDebugLrScValid = Bool()
   val debugInfo = new PerfDebugInfo
+  def needRfRPort(index: Int, rfType: Int) : Bool = {
+    (index, rfType) match {
+      case (0, 0) => ctrl.src1Type === SrcType.reg && ctrl.lsrc1 =/= 0.U && src1State === SrcState.rdy
+      case (1, 0) => ctrl.src2Type === SrcType.reg && ctrl.lsrc2 =/= 0.U && src1State === SrcState.rdy
+      case (0, 1) => ctrl.src1Type === SrcType.fp && src1State === SrcState.rdy
+      case (1, 1) => ctrl.src2Type === SrcType.fp && src1State === SrcState.rdy
+      case (2, 1) => ctrl.src3Type === SrcType.fp && src1State === SrcState.rdy
+      case _ => false.B
+    }
+  }
 }
 
 class Redirect(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/backend/FloatBlock.scala
+++ b/src/main/scala/xiangshan/backend/FloatBlock.scala
@@ -94,7 +94,7 @@ class FloatBlock
 
   // val readPortIndex = RegNext(io.fromCtrlBlock.readPortIndex)
   val readPortIndex = Seq(0, 1, 2, 3, 2, 3)
-  val reservedStations = exeUnits.map(_.config).zipWithIndex.map({ case (cfg, i) =>
+  val reservationStations = exeUnits.map(_.config).zipWithIndex.map({ case (cfg, i) =>
     var certainLatency = -1
     if (cfg.hasCertainLatency) {
       certainLatency = cfg.latency.latencyVal.get
@@ -150,8 +150,8 @@ class FloatBlock
     rs
   })
 
-  for(rs <- reservedStations){
-    val inBlockUops = reservedStations.filter(x =>
+  for(rs <- reservationStations){
+    val inBlockUops = reservationStations.filter(x =>
       x.exuCfg.hasCertainLatency && x.exuCfg.writeFpRf
     ).map(x => {
       val raw = WireInit(x.io.fastUopOut)
@@ -227,4 +227,8 @@ class FloatBlock
     difftest.io.coreid := 0.U
     difftest.io.fpr    := VecInit(fpRf.io.debug_rports.map(p => ieee(p.data)))
   }
+
+  val rsDeqCount = PopCount(reservationStations.map(_.io.deq.valid))
+  XSPerfAccumulate("fp_rs_deq_count", rsDeqCount)
+  XSPerfHistogram("fp_rs_deq_count", rsDeqCount, true.B, 0, 6, 1)
 }

--- a/src/main/scala/xiangshan/backend/IntegerBlock.scala
+++ b/src/main/scala/xiangshan/backend/IntegerBlock.scala
@@ -3,7 +3,7 @@ package xiangshan.backend
 import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
-import utils.XSPerfAccumulate
+import utils._
 import xiangshan._
 import xiangshan.backend.exu._
 import xiangshan.backend.issue.ReservationStation
@@ -275,4 +275,7 @@ class IntegerBlock
     difftest.io.gpr    := VecInit(intRf.io.debug_rports.map(_.data))
   }
 
+  val rsDeqCount = PopCount(reservationStations.map(_.io.deq.valid))
+  XSPerfAccumulate("int_rs_deq_count", rsDeqCount)
+  XSPerfHistogram("int_rs_deq_count", rsDeqCount, true.B, 0, 7, 1)
 }


### PR DESCRIPTION
In this commit, we add performance counters for dispatch and issue stages
to track the number of instructions dispatched and issued. Active regfile
read ports are counted as ready instruction source registers.