### PR TITLE
LoadUnit: block writeback when the instruction is an MMIO access

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -327,7 +327,7 @@ class LoadUnit extends XSModule with HasLoadHelper {
   io.lsq.loadIn.bits := load_s2.io.out.bits
 
   // write to rob and writeback bus
-  val s2_wb_valid = load_s2.io.out.valid && !load_s2.io.out.bits.miss
+  val s2_wb_valid = load_s2.io.out.valid && !load_s2.io.out.bits.miss && !load_s2.io.out.bits.mmio
 
   // Int load, if hit, will be writebacked at s2
   val hitLoadOut = Wire(Valid(new ExuOutput))


### PR DESCRIPTION
MMIO should never hit in DCache. However, DCache does not guarantee the miss
is strictly according to the vaddr, paddr provided by the pipeline, when the
load is killed. That is, DCache may response valid = false and miss = false
when the MMIO instruction is accessed and then killed.