### PR TITLE
Makefile.emu: temporarily disable pipe for EMU_COMPILE

### DIFF
--- a/Makefile.emu
+++ b/Makefile.emu
@@ -86,7 +86,8 @@ $(EMU_MK): $(SIM_TOP_V) | $(EMU_DEPS)
 
 LOCK = /var/emu/emu.lock
 LOCK_BIN = $(abspath $(BUILD_DIR)/lock-emu)
-EMU_COMPILE_FILTER = 2> $(BUILD_DIR)/g++.err.log | tee $(BUILD_DIR)/g++.out.log | grep 'g++' | awk '{print "Compiling/Generating", $$NF}'
+EMU_COMPILE_FILTER =
+# 2> $(BUILD_DIR)/g++.err.log | tee $(BUILD_DIR)/g++.out.log | grep 'g++' | awk '{print "Compiling/Generating", $$NF}'
 
 build_emu_local: $(EMU_MK)
 	@echo "\n[g++] Compiling C++ files..." >> $(TIMELOG)


### PR DESCRIPTION
Pipe causes the return value of make command ignored. Pipe is disabled for
cpp compilation output until we find an elegant solution to exit on errors.