### PR TITLE
difftest: fix width of intrNO

### DIFF
--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -28,7 +28,7 @@ typedef struct {
 // architectural events: interrupts and exceptions
 // whose priority should be higher than normal commits
 typedef struct {
-  uint32_t interrupt = 0;
+  uint64_t interrupt = 0;
   uint32_t exception = 0;
   uint64_t exceptionPC = 0;
 } arch_event_t;

--- a/src/test/csrc/difftest/interface.h
+++ b/src/test/csrc/difftest/interface.h
@@ -41,7 +41,7 @@ extern "C" int v_difftest_step();
 #define INTERFACE_ARCH_EVENT             \
   DIFFTEST_DPIC_FUNC_DECL(ArchEvent) (   \
     DPIC_ARG_BYTE coreid,                \
-    DPIC_ARG_INT  intrNo,                \
+    DPIC_ARG_LONG intrNo,                \
     DPIC_ARG_INT  cause,                 \
     DPIC_ARG_LONG exceptionPC            \
   )

--- a/src/test/vsrc/difftest.v
+++ b/src/test/vsrc/difftest.v
@@ -33,14 +33,14 @@
 // DifftestArchEvent
 `DIFFTEST_DPIC_FUNC_DECL(ArchEvent) (
   `DPIC_ARG_BYTE coreid,
-  `DPIC_ARG_INT  intrNo,
+  `DPIC_ARG_LONG intrNo,
   `DPIC_ARG_INT  cause,
   `DPIC_ARG_LONG exceptionPC
 );
 `DIFFTEST_MOD_DECL(ArchEvent) (
   input        clock,
   input [ 7:0] coreid,
-  input [31:0] intrNO,
+  input [63:0] intrNO,
   input [31:0] cause,
   input [63:0] exceptionPC
 );


### PR DESCRIPTION
* cuz the most significant bit of intrNO is useful to identify
interrupts in NEMU