### PR TITLE
cache: support fake dcache, ptw, l1pluscache, l2cache and l3cache

### DIFF
--- a/Makefile.emu
+++ b/Makefile.emu
@@ -74,7 +74,9 @@ VERILATOR_FLAGS =                   \
 
 EMU_MK := $(BUILD_DIR)/emu-compile/V$(EMU_TOP).mk
 EMU_DEPS := $(EMU_VFILES) $(EMU_CXXFILES)
-EMU_HEADERS := $(shell find $(EMU_CSRC_DIR) -name "*.h")
+EMU_HEADERS := $(shell find $(EMU_CSRC_DIR) -name "*.h")     \
+               $(shell find $(SIM_CSRC_DIR) -name "*.h")     \
+               $(shell find $(DIFFTEST_CSRC_DIR) -name "*.h")
 EMU := $(BUILD_DIR)/emu
 
 $(EMU_MK): $(SIM_TOP_V) | $(EMU_DEPS)

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -16,6 +16,7 @@ case class SoCParameters
 ){
   val PAddrBits = cores.map(_.PAddrBits).reduce((x, y) => if(x > y) x else y)
   // L3 configurations
+  val useFakeL3Cache = false
   val L3InnerBusWidth = 256
   val L3Size = 4 * 1024 * 1024 // 4MB
   val L3BlockSize = 64
@@ -36,6 +37,7 @@ trait HasSoCParameter {
   val EnableILA = soc.EnableILA
 
   // L3 configurations
+  val useFakeL3Cache = soc.useFakeL3Cache
   val L3InnerBusWidth = soc.L3InnerBusWidth
   val L3Size = soc.L3Size
   val L3BlockSize = soc.L3BlockSize

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -24,8 +24,7 @@ class XSCoreWithL2()(implicit p: Parameters) extends LazyModule
   private val core = LazyModule(new XSCore())
   private val l2prefetcher = LazyModule(new L2Prefetcher())
   private val l2xbar = TLXbar()
-
-  val l2cache = LazyModule(new InclusiveCache(
+  private val l2cache = if (useFakeL2Cache) null else LazyModule(new InclusiveCache(
     CacheParameters(
       level = 2,
       ways = L2NWays,
@@ -42,13 +41,27 @@ class XSCoreWithL2()(implicit p: Parameters) extends LazyModule
     ),
     fpga = debugOpts.FPGAPlatform
   ))
+
+  val memory_port = TLIdentityNode()
   val uncache = TLXbar()
 
-  l2xbar := TLBuffer() := core.memBlock.dcache.clientNode
-  l2xbar := TLBuffer() := core.l1pluscache.clientNode
-  l2xbar := TLBuffer() := core.ptw.node
+  if (!useFakeDCache) {
+    l2xbar := TLBuffer() := core.memBlock.dcache.clientNode
+  }
+  if (!useFakeL1plusCache) {
+    l2xbar := TLBuffer() := core.l1pluscache.clientNode
+  }
+  if (!useFakePTW) {
+    l2xbar := TLBuffer() := core.ptw.node
+  }
   l2xbar := TLBuffer() := l2prefetcher.clientNode
-  l2cache.node := TLBuffer() := l2xbar
+  if (useFakeL2Cache) {
+    memory_port := l2xbar
+  }
+  else {
+    l2cache.node := TLBuffer() := l2xbar
+    memory_port := l2cache.node
+  }
 
   uncache := TLBuffer() := core.frontend.instrUncache.clientNode
   uncache := TLBuffer() := core.memBlock.uncache.clientNode
@@ -63,7 +76,12 @@ class XSCoreWithL2()(implicit p: Parameters) extends LazyModule
     core.module.io.hartId := io.hartId
     core.module.io.externalInterrupt := io.externalInterrupt
     l2prefetcher.module.io.enable := core.module.io.l2_pf_enable
-    l2prefetcher.module.io.in <> l2cache.module.io
+    if (useFakeL2Cache) {
+      l2prefetcher.module.io.in := DontCare
+    }
+    else {
+      l2prefetcher.module.io.in <> l2cache.module.io
+    }
     io.l1plus_error <> core.module.io.l1plus_error
     io.icache_error <> core.module.io.icache_error
     io.dcache_error <> core.module.io.dcache_error
@@ -73,7 +91,9 @@ class XSCoreWithL2()(implicit p: Parameters) extends LazyModule
 
     val l2_reset_gen = Module(new ResetGen(1, !debugOpts.FPGAPlatform))
     l2prefetcher.module.reset := l2_reset_gen.io.out
-    l2cache.module.reset := l2_reset_gen.io.out
+    if (!useFakeL2Cache) {
+      l2cache.module.reset := l2_reset_gen.io.out
+    }
   }
 }
 
@@ -201,7 +221,7 @@ class XSTopWithoutDMA()(implicit p: Parameters) extends BaseXSSoc()
 
   for (i <- 0 until NumCores) {
     peripheralXbar := TLBuffer() := core_with_l2(i).uncache
-    l3_xbar := TLBuffer() := core_with_l2(i).l2cache.node
+    l3_xbar := TLBuffer() := core_with_l2(i).memory_port
   }
 
   private val clint = LazyModule(new TLTimer(
@@ -232,7 +252,7 @@ class XSTopWithoutDMA()(implicit p: Parameters) extends BaseXSSoc()
   ))
   plic.node := AXI4IdentityNode() := AXI4UserYanker() := TLToAXI4() := peripheralXbar
 
-  val l3cache = LazyModule(new InclusiveCache(
+  val l3cache = if (useFakeL3Cache) null else LazyModule(new InclusiveCache(
     CacheParameters(
       level = 3,
       ways = L3NWays,
@@ -249,8 +269,14 @@ class XSTopWithoutDMA()(implicit p: Parameters) extends BaseXSSoc()
     ),
     fpga = debugOpts.FPGAPlatform
   ))
+  val l3Ignore = if (useFakeL3Cache) TLIgnoreNode() else null
 
-  bankedNode :*= l3cache.node :*= TLBuffer() :*= l3_xbar
+  if (useFakeL3Cache) {
+    bankedNode :*= l3Ignore :*= l3_xbar
+  }
+  else {
+    bankedNode :*= l3cache.node :*= TLBuffer() :*= l3_xbar
+  }
 
   lazy val module = new LazyRawModuleImp(this) {
     val io = IO(new Bundle {
@@ -284,9 +310,11 @@ class XSTopWithoutDMA()(implicit p: Parameters) extends BaseXSSoc()
         beu.module.io.errors.dcache(i) := core_with_l2(i).module.io.dcache_error
       }
 
-      val l3_reset_gen = Module(new ResetGen(1, !debugOpts.FPGAPlatform))
-      l3_reset_gen.suggestName("l3_reset_gen")
-      l3cache.module.reset := l3_reset_gen.io.out
+      if (!useFakeL3Cache) {
+        val l3_reset_gen = Module(new ResetGen(1, !debugOpts.FPGAPlatform))
+        l3_reset_gen.suggestName("l3_reset_gen")
+        l3cache.module.reset := l3_reset_gen.io.out
+      }
     }
   }
 }

--- a/src/main/scala/utils/TLIgnoreNode.scala
+++ b/src/main/scala/utils/TLIgnoreNode.scala
@@ -1,0 +1,64 @@
+package utils
+
+import chisel3._
+import chipsalliance.rocketchip.config.Parameters
+import chisel3.util.DecoupledIO
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+
+class TLIgnoreNode()(implicit p: Parameters) extends LazyModule  {
+
+  val xfer = TransferSizes(1, 64)
+
+  val node : TLAdapterNode = TLAdapterNode(
+    clientFn  = { _ => TLClientPortParameters(Seq(TLClientParameters(
+      name          = s"Ignore",
+      sourceId      = IdRange(0, 1),
+      supportsProbe = xfer)))
+    },
+    managerFn = { m => TLManagerPortParameters(
+      managers = m.managers.map { m => m.copy(
+        regionType         = if (m.regionType >= RegionType.UNCACHED) RegionType.CACHED else m.regionType,
+        supportsAcquireB   = xfer,
+        supportsAcquireT   = xfer,
+        supportsArithmetic = xfer,
+        supportsLogical    = xfer,
+        supportsGet        = xfer,
+        supportsPutFull    = xfer,
+        supportsPutPartial = xfer,
+        supportsHint       = xfer,
+        alwaysGrantsT      = false,
+        fifoId             = None)
+      },
+      beatBytes  = 32,
+      endSinkId  = 1,
+      minLatency = 1)
+    }
+  )
+
+  lazy val module = new LazyModuleImp(this) {
+    for ((out, _) <- node.out) {
+      out := DontCare
+      out.a.valid := false.B
+      out.b.ready := true.B
+      out.c.valid := false.B
+      out.d.ready := true.B
+      out.e.valid := false.B
+    }
+    for ((in, _) <- node.in) {
+      in := DontCare
+      in.a.ready := true.B
+      in.b.valid := false.B
+      in.c.ready := true.B
+      in.d.valid := false.B
+      in.e.ready := true.B
+    }
+  }
+}
+
+object TLIgnoreNode {
+  def apply()(implicit p: Parameters): TLAdapterNode = {
+    val ignoreNode = LazyModule(new TLIgnoreNode())
+    ignoreNode.node
+  }
+}

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -197,6 +197,7 @@ trait HasXSParameter {
   val DTLBWidth = coreParams.LoadPipelineWidth + coreParams.StorePipelineWidth
   val TlbEntrySize = coreParams.TlbEntrySize
   val TlbSPEntrySize = coreParams.TlbSPEntrySize
+  val useFakePTW = false
   val PtwL3EntrySize = coreParams.PtwL3EntrySize
   val PtwSPEntrySize = coreParams.PtwSPEntrySize
   val PtwL1EntrySize = coreParams.PtwL1EntrySize
@@ -213,6 +214,7 @@ trait HasXSParameter {
     nMissEntries = 2
   )
 
+  val useFakeL1plusCache = false
   val l1plusCacheParameters = L1plusCacheParameters(
     tagECC = Some("secded"),
     dataECC = Some("secded"),
@@ -220,6 +222,7 @@ trait HasXSParameter {
     nMissEntries = 8
   )
 
+  val useFakeDCache = false
   val dcacheParameters = DCacheParameters(
     tagECC = Some("secded"),
     dataECC = Some("secded"),
@@ -237,6 +240,7 @@ trait HasXSParameter {
   val l1BusDataWidth = 256
 
   // L2 configurations
+  val useFakeL2Cache = useFakeDCache && useFakePTW && useFakeL1plusCache
   val L1BusWidth = 256
   val L2Size = 512 * 1024 // 512KB
   val L2BlockSize = 64
@@ -245,7 +249,7 @@ trait HasXSParameter {
 
   // L3 configurations
   val L2BusWidth = 256
-  
+
   // icache prefetcher
   val l1plusPrefetcherParameters = L1plusPrefetcherParameters(
     enable = true,
@@ -283,12 +287,13 @@ trait HasXSParameter {
     ),
   )
 
-  val loadExuConfigs = coreParams.loadExuConfigs 
-  val storeExuConfigs = coreParams.storeExuConfigs 
+  val loadExuConfigs = coreParams.loadExuConfigs
+  val storeExuConfigs = coreParams.storeExuConfigs
 
-  val intExuConfigs = coreParams.intExuConfigs 
+  val intExuConfigs = coreParams.intExuConfigs
 
-  val fpExuConfigs = coreParams.fpExuConfigs 
+  val fpExuConfigs = coreParams.fpExuConfigs
 
-  val exuConfigs = coreParams.exuConfigs 
+  val exuConfigs = coreParams.exuConfigs
+
 }

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -7,7 +7,7 @@ import xiangshan.backend.fu.HasExceptionNO
 import xiangshan.backend.dispatch.DispatchParameters
 import xiangshan.frontend._
 import xiangshan.mem._
-import xiangshan.cache.{DCacheParameters, ICacheParameters, L1plusCache, L1plusCacheParameters, PTW, PTWRepeater}
+import xiangshan.cache.{DCacheParameters, ICacheParameters, L1plusCacheWrapper, L1plusCacheParameters, PTWWrapper, PTWRepeater}
 import xiangshan.cache.prefetch._
 import chipsalliance.rocketchip.config
 import chipsalliance.rocketchip.config.Parameters
@@ -59,8 +59,8 @@ class XSCore()(implicit p: config.Parameters) extends LazyModule
   with HasExeBlockHelper {
   // outer facing nodes
   val frontend = LazyModule(new Frontend())
-  val l1pluscache = LazyModule(new L1plusCache())
-  val ptw = LazyModule(new PTW())
+  val l1pluscache = LazyModule(new L1plusCacheWrapper())
+  val ptw = LazyModule(new PTWWrapper())
   val memBlock = LazyModule(new MemBlock(
     fastWakeUpIn = intExuConfigs.filter(_.hasCertainLatency),
     slowWakeUpIn = intExuConfigs.filter(_.hasUncertainlatency) ++ fpExuConfigs,

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -38,7 +38,7 @@ class MemBlock(
   val numIntWakeUpFp: Int
 )(implicit p: Parameters) extends LazyModule {
 
-  val dcache = LazyModule(new DCache())
+  val dcache = LazyModule(new DCacheWrapper())
   val uncache = LazyModule(new Uncache())
 
   lazy val module = new MemBlockImp(this)

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -9,6 +9,7 @@ import xiangshan.cache._
 import xiangshan.cache.{DCacheWordIO, DCacheLineIO, TlbRequestIO, MemoryOpConstants}
 import xiangshan.backend.roq.RoqLsqIO
 import difftest._
+import device.RAMHelper
 
 class SqPtr(implicit p: Parameters) extends CircularQueuePtr[SqPtr](
   p => p(XSCoreParamsKey).StoreQueueSize
@@ -373,6 +374,19 @@ class StoreQueue(implicit p: Parameters) extends XSModule with HasDCacheParamete
   }
   when (io.sbuffer(1).fire()) {
     assert(io.sbuffer(0).fire())
+  }
+  if (useFakeDCache) {
+    for (i <- 0 until StorePipelineWidth) {
+      val ptr = deqPtrExt(i).value
+      val fakeRAM = Module(new RAMHelper(64L * 1024 * 1024 * 1024))
+      fakeRAM.io.clk   := clock
+      fakeRAM.io.en    := allocated(ptr) && commited(ptr) && !mmio(ptr)
+      fakeRAM.io.rIdx  := 0.U
+      fakeRAM.io.wIdx  := (paddrModule.io.rdata(i) - "h80000000".U) >> 3
+      fakeRAM.io.wdata := dataModule.io.rdata(i).data
+      fakeRAM.io.wmask := MaskExpand(dataModule.io.rdata(i).mask)
+      fakeRAM.io.wen   := allocated(ptr) && commited(ptr) && !mmio(ptr)
+    }
   }
 
   if (!env.FPGAPlatform) {

--- a/src/test/csrc/common/ram.h
+++ b/src/test/csrc/common/ram.h
@@ -14,6 +14,9 @@ long get_ram_size();
 void* get_img_start();
 long get_img_size();
 
+uint64_t pmem_read(uint64_t raddr);
+void pmem_write(uint64_t waddr, uint64_t wdata);
+
 #ifdef WITH_DRAMSIM3
 #include "axi4.h"
 

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -148,7 +148,7 @@ void Difftest::do_interrupt() {
 void Difftest::do_exception() {
   state->record_abnormal_inst(dut.event.exceptionPC, dut.commit[0].inst, RET_EXC, dut.event.exception);
   if (dut.event.exception == 12 || dut.event.exception == 13 || dut.event.exception == 15) {
-    printf("exception cause: %d\n", dut.event.exception);
+    // printf("exception cause: %d\n", dut.event.exception);
     struct DisambiguationState ds;
     ds.exceptionNo = dut.event.exception;
     ds.mtval = dut.csr.mtval;

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -21,8 +21,8 @@ typedef struct {
   uint8_t  valid = 0;
   uint8_t  code;
   uint64_t pc;
-  uint64_t cycleCnt;
-  uint64_t instrCnt;
+  uint64_t cycleCnt = 0;
+  uint64_t instrCnt = 0;
 } trap_event_t;
 
 // architectural events: interrupts and exceptions

--- a/src/test/csrc/difftest/ref.cpp
+++ b/src/test/csrc/difftest/ref.cpp
@@ -1,0 +1,106 @@
+#include "ref.h"
+#include "ram.h"
+
+typedef union PageTableEntry {
+  struct {
+    uint32_t v   : 1;
+    uint32_t r   : 1;
+    uint32_t w   : 1;
+    uint32_t x   : 1;
+    uint32_t u   : 1;
+    uint32_t g   : 1;
+    uint32_t a   : 1;
+    uint32_t d   : 1;
+    uint32_t rsw : 2;
+    uint64_t ppn :44;
+    uint32_t pad :10;
+  };
+  uint64_t val;
+} PTE;
+
+#define VPNi(vpn, i) (((vpn) >> (18 - 9 * (i))) & 0x1ff)
+
+extern "C" uint8_t pte_helper(uint64_t satp, uint64_t vpn, uint64_t *pte, uint8_t *level) {
+  uint64_t pg_base = satp << 12, pte_addr;
+  PTE *pte_p = (PTE *)pte;
+  for (*level = 0; *level < 3; (*level)++) {
+    pte_addr = pg_base + VPNi(vpn, *level) * sizeof(uint64_t);
+    pte_p->val = pmem_read(pte_addr);
+    pg_base = pte_p->ppn << 12;
+    // pf
+    if (!pte_p->v) {
+      return 1;
+    }
+    // leaf pte
+    if (pte_p->r || pte_p->x) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+enum {
+  M_XA_SWAP = 4,
+  M_XLR = 6,
+  M_XSC = 7,
+  M_XA_ADD  = 8,
+  M_XA_XOR  = 9,
+  M_XA_OR   = 10,
+  M_XA_AND  = 11,
+  M_XA_MIN  = 12,
+  M_XA_MAX  = 13,
+  M_XA_MINU = 14,
+  M_XA_MAXU = 15
+};
+
+#define SEXT32(data)        ((uint64_t)(data) | ((data >> 31) ? (0xffffffffUL << 32) : 0))
+#define GET_LOWER32(data)   ((data) & ((1UL << 32) - 1))
+#define GET_UPPER32(data)   ((data) >> 32)
+
+extern "C" uint64_t amo_helper(uint8_t cmd, uint64_t addr, uint64_t wdata, uint8_t mask) {
+  if (addr % 8 == 4 && mask == 0xf0) {
+    addr -= 4;
+  }
+  else if (addr % 8 != 0) {
+    printf("warning: amo address %lx not naturally aligned to %x!!\n", addr, mask);
+  }
+  if (mask != 0xff && mask != 0xf && mask != 0xf0) {
+    printf("warning: amo data mask %x not aligned to 32-bit\n", mask);
+  }
+  static uint64_t lr_addr = 0, lr_valid = 0;
+  uint64_t rdata = pmem_read(addr);
+  uint64_t upper_r = GET_UPPER32(rdata), upper_w = GET_UPPER32(wdata);
+  uint64_t lower_r = GET_LOWER32(rdata), lower_w = GET_LOWER32(wdata);
+  uint64_t rop = (mask == 0xff) ? rdata : (mask == 0xf) ? lower_r : upper_r;
+  uint64_t wop = (mask == 0xff) ? wdata : (mask == 0xf) ? lower_w : upper_w;
+  uint64_t result = 0;
+  switch (cmd) {
+    case M_XA_SWAP: result = wop; break;
+    case M_XLR: result = rdata; lr_valid = 1; lr_addr = addr; break;
+    // always succeed
+    case M_XSC: rop = !(lr_valid && lr_addr == addr); lr_valid = 0; result = wop; break;
+    case M_XA_ADD:  result = wop + rop; break;
+    case M_XA_XOR:  result = wop ^ rop; break;
+    case M_XA_OR:   result = wop | rop; break;
+    case M_XA_AND:  result = wop & rop; break;
+    case M_XA_MIN:
+      if (mask == 0xff) result = ((int64_t)wop > (int64_t)rop) ? rop : wop;
+      else result = ((int32_t)((uint32_t)wop) > (int32_t)((uint32_t)rop)) ? rop : wop;
+      break;
+    case M_XA_MAX:
+      if (mask == 0xff) result = ((int64_t)wop > (int64_t)rop) ? wop : rop;
+      else result = ((int32_t)((uint32_t)wop) > (int32_t)((uint32_t)rop)) ? wop : rop;
+      break;
+    case M_XA_MINU: result = (wop > rdata) ? rop : wop; break;
+    case M_XA_MAXU: result = (wop > rdata) ? wop : rop; break;
+    default: printf("unknown atomic op %d!!\n", cmd); break;
+  }
+  if (mask == 0xf) {
+    result = (upper_r << 32) | (result & 0xffffffffUL);
+  }
+  else if (mask == 0xf0) {
+    result = (result << 32) | lower_r;
+  }
+  pmem_write(addr, result);
+  return (mask == 0xf0) ? rop << 32 : rop;
+}

--- a/src/test/csrc/difftest/ref.h
+++ b/src/test/csrc/difftest/ref.h
@@ -1,0 +1,12 @@
+/**
+ * Headers for C/C++ REF models
+ */
+#ifndef __DT_REF_H__
+#define __DT_REF_H__
+
+#include "difftest.h"
+
+// REF Models
+extern "C" uint8_t pte_helper(uint64_t satp, uint64_t vpn, uint64_t *pte, uint8_t *level);
+
+#endif

--- a/src/test/vsrc/ref.v
+++ b/src/test/vsrc/ref.v
@@ -1,0 +1,47 @@
+import "DPI-C" function byte pte_helper (
+  input  longint satp,
+  input  longint vpn,
+  output longint pte,
+  output byte    level
+);
+
+module PTEHelper(
+  input             clock,
+  input             enable,
+  input      [63:0] satp,
+  input      [63:0] vpn,
+  output reg [63:0] pte,
+  output reg [ 7:0] level,
+  output reg [ 7:0] pf
+);
+  always @(posedge clock) begin
+    if (enable) begin
+      pf <= pte_helper(satp, vpn, pte, level);
+    end
+  end
+endmodule
+
+import "DPI-C" function longint amo_helper(
+  input byte    cmd,
+  input longint addr,
+  input longint wdata,
+  input byte    mask
+);
+
+module AMOHelper(
+  input             clock,
+  input             enable,
+  input      [ 4:0] cmd,
+  input      [63:0] addr,
+  input      [63:0] wdata,
+  input      [ 7:0] mask,
+  output reg [63:0] rdata
+);
+
+  always @(posedge clock) begin
+    if (enable) begin
+      rdata <= amo_helper(cmd, addr, wdata, mask);
+    end
+  end
+
+endmodule


### PR DESCRIPTION
In this commit, we add support for using DPI-C calls to replace
DCache, PTW and L1plusCache. L2Cache and L3 Cache are also allowed to
be ignored or bypassed. Configurations are controlled by useFakeDCache,
useFakePTW, useFakeL1plusCache, useFakeL2Cache and useFakeL3Cache.
However, some configurations may not work correctly.