### PR TITLE
bundle,uop: use Vec for lsrc, psrc, srcState and srcType

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -251,8 +251,8 @@ class FPUCtrlSignals(implicit p: Parameters) extends XSBundle {
 
 // Decode DecodeWidth insts at Decode Stage
 class CtrlSignals(implicit p: Parameters) extends XSBundle {
-  val src1Type, src2Type, src3Type = SrcType()
-  val lsrc1, lsrc2, lsrc3 = UInt(5.W)
+  val srcType = Vec(3, SrcType())
+  val lsrc = Vec(3, UInt(5.W))
   val ldest = UInt(5.W)
   val fuType = FuType()
   val fuOpType = FuOpType()
@@ -272,7 +272,7 @@ class CtrlSignals(implicit p: Parameters) extends XSBundle {
   def decode(inst: UInt, table: Iterable[(BitPat, List[BitPat])]) = {
     val decoder = freechips.rocketchip.rocket.DecodeLogic(inst, XDecode.decodeDefault, table)
     val signals =
-      Seq(src1Type, src2Type, src3Type, fuType, fuOpType, rfWen, fpWen,
+      Seq(srcType(0), srcType(1), srcType(2), fuType, fuOpType, rfWen, fpWen,
         isXSTrap, noSpecExec, blockBackward, flushPipe, isRVF, selImm)
     signals zip decoder map { case (s, d) => s := d }
     commitType := DontCare
@@ -304,8 +304,10 @@ class LSIdx(implicit p: Parameters) extends XSBundle {
 
 // CfCtrl -> MicroOp at Rename Stage
 class MicroOp(implicit p: Parameters) extends CfCtrl {
-  val psrc1, psrc2, psrc3, pdest, old_pdest = UInt(PhyRegIdxWidth.W)
-  val src1State, src2State, src3State = SrcState()
+  val srcState = Vec(3, SrcState())
+  val psrc = Vec(3, UInt(PhyRegIdxWidth.W))
+  val pdest =UInt(PhyRegIdxWidth.W)
+  val old_pdest = UInt(PhyRegIdxWidth.W)
   val roqIdx = new RoqPtr
   val lqIdx = new LqPtr
   val sqIdx = new SqPtr
@@ -313,11 +315,11 @@ class MicroOp(implicit p: Parameters) extends CfCtrl {
   val debugInfo = new PerfDebugInfo
   def needRfRPort(index: Int, rfType: Int, ignoreState: Boolean = true) : Bool = {
     (index, rfType) match {
-      case (0, 0) => ctrl.src1Type === SrcType.reg && ctrl.lsrc1 =/= 0.U && (src1State === SrcState.rdy || ignoreState.B)
-      case (1, 0) => ctrl.src2Type === SrcType.reg && ctrl.lsrc2 =/= 0.U && (src2State === SrcState.rdy || ignoreState.B)
-      case (0, 1) => ctrl.src1Type === SrcType.fp && (src1State === SrcState.rdy || ignoreState.B)
-      case (1, 1) => ctrl.src2Type === SrcType.fp && (src2State === SrcState.rdy || ignoreState.B)
-      case (2, 1) => ctrl.src3Type === SrcType.fp && (src3State === SrcState.rdy || ignoreState.B)
+      case (0, 0) => ctrl.srcType(0) === SrcType.reg && ctrl.lsrc(0) =/= 0.U && (srcState(0) === SrcState.rdy || ignoreState.B)
+      case (1, 0) => ctrl.srcType(1) === SrcType.reg && ctrl.lsrc(1) =/= 0.U && (srcState(1) === SrcState.rdy || ignoreState.B)
+      case (0, 1) => ctrl.srcType(0) === SrcType.fp && (srcState(0) === SrcState.rdy || ignoreState.B)
+      case (1, 1) => ctrl.srcType(1) === SrcType.fp && (srcState(1) === SrcState.rdy || ignoreState.B)
+      case (2, 1) => ctrl.srcType(2) === SrcType.fp && (srcState(2) === SrcState.rdy || ignoreState.B)
       case _ => false.B
     }
   }

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch1.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch1.scala
@@ -66,7 +66,7 @@ class Dispatch1(implicit p: Parameters) extends XSModule with HasExceptionNO {
 
   /**
     * Part 2:
-    *   Update commitType, psrc1, psrc2, psrc3, old_pdest, roqIdx, lqIdx, sqIdx for the uops
+    *   Update commitType, psrc(0), psrc(1), psrc(2), old_pdest, roqIdx, lqIdx, sqIdx for the uops
     */
   val updatedUop = Wire(Vec(RenameWidth, new MicroOp))
   val updatedCommitType = Wire(Vec(RenameWidth, CommitType()))
@@ -79,17 +79,17 @@ class Dispatch1(implicit p: Parameters) extends XSModule with HasExceptionNO {
     updatedCommitType(i) := Cat(isLs(i), (isStore(i) && !isAMO(i)) | isBranch(i))
     val pdestBypassedPsrc1 = io.fromRename.take(i).map(_.bits.pdest)
       .zip(if (i == 0) Seq() else io.renameBypass.lsrc1_bypass(i-1).asBools)
-      .foldLeft(io.fromRename(i).bits.psrc1) {
+      .foldLeft(io.fromRename(i).bits.psrc(0)) {
         (z, next) => Mux(next._2, next._1, z)
       }
     val pdestBypassedPsrc2 = io.fromRename.take(i).map(_.bits.pdest)
       .zip(if (i == 0) Seq() else io.renameBypass.lsrc2_bypass(i-1).asBools)
-      .foldLeft(io.fromRename(i).bits.psrc2) {
+      .foldLeft(io.fromRename(i).bits.psrc(1)) {
         (z, next) => Mux(next._2, next._1, z)
       }
     val pdestBypassedPsrc3 = io.fromRename.take(i).map(_.bits.pdest)
       .zip(if (i == 0) Seq() else io.renameBypass.lsrc3_bypass(i-1).asBools)
-      .foldLeft(io.fromRename(i).bits.psrc3) {
+      .foldLeft(io.fromRename(i).bits.psrc(2)) {
         (z, next) => Mux(next._2, next._1, z)
       }
     val pdestBypassedOldPdest = io.fromRename.take(i).map(_.bits.pdest)
@@ -102,7 +102,7 @@ class Dispatch1(implicit p: Parameters) extends XSModule with HasExceptionNO {
       updatedPsrc2(i) := pdestBypassedPsrc2
     }
     else {
-      // for move elimination, the psrc1/psrc2 of consumer instruction always come from psrc1 of move
+      // for move elimination, the psrc(0)/psrc(1) of consumer instruction always come from psrc(0) of move
       updatedPsrc1(i) := Mux(io.renameBypass.move_eliminated_src1(i-1), updatedPsrc1(i-1), pdestBypassedPsrc1)
       updatedPsrc2(i) := Mux(io.renameBypass.move_eliminated_src2(i-1), updatedPsrc1(i-1), pdestBypassedPsrc2)
     }
@@ -110,10 +110,10 @@ class Dispatch1(implicit p: Parameters) extends XSModule with HasExceptionNO {
     updatedOldPdest(i) := pdestBypassedOldPdest
 
     updatedUop(i) := io.fromRename(i).bits
-    // update bypass psrc1/psrc2/psrc3/old_pdest
-    updatedUop(i).psrc1 := updatedPsrc1(i)
-    updatedUop(i).psrc2 := updatedPsrc2(i)
-    updatedUop(i).psrc3 := updatedPsrc3(i)
+    // update bypass psrc(0)/psrc(1)/psrc(2)/old_pdest
+    updatedUop(i).psrc(0) := updatedPsrc1(i)
+    updatedUop(i).psrc(1) := updatedPsrc2(i)
+    updatedUop(i).psrc(2) := updatedPsrc3(i)
     updatedUop(i).old_pdest := updatedOldPdest(i)
     updatedUop(i).debugInfo.src1MoveElim := (if (i == 0) false.B else io.renameBypass.move_eliminated_src1(i-1))
     updatedUop(i).debugInfo.src2MoveElim := (if (i == 0) false.B else io.renameBypass.move_eliminated_src2(i-1))

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch2Fp.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch2Fp.scala
@@ -51,31 +51,31 @@ class Dispatch2Fp(implicit p: Parameters) extends XSModule {
   // val fpDynamicMapped = fpDynamicIndex.map(i => indexVec(i))
   // for (i <- fpStaticIndex.indices) {
   //   val index = WireInit(VecInit(fpStaticMapped(i) +: fpDynamicMapped))
-  //   io.readRf(3*i  ) := io.fromDq(index(fpReadPortSrc(i))).bits.psrc1
-  //   io.readRf(3*i+1) := io.fromDq(index(fpReadPortSrc(i))).bits.psrc2
-  //   io.readRf(3*i+2) := io.fromDq(index(fpReadPortSrc(i))).bits.psrc3
+  //   io.readRf(3*i  ) := io.fromDq(index(fpReadPortSrc(i))).bits.psrc(0)
+  //   io.readRf(3*i+1) := io.fromDq(index(fpReadPortSrc(i))).bits.psrc(1)
+  //   io.readRf(3*i+2) := io.fromDq(index(fpReadPortSrc(i))).bits.psrc(2)
   // }
   // val readPortIndex = Wire(Vec(exuParameters.FpExuCnt, UInt(2.W)))
   // fpStaticIndex.zipWithIndex.map({case (index, i) => readPortIndex(index) := i.U})
   // fpDynamicIndex.zipWithIndex.map({case (index, i) => readPortIndex(index) := fpDynamicExuSrc(i)})
 
   for (i <- 0 until dpParams.IntDqDeqWidth) {
-    io.readState(3*i  ).req := io.fromDq(i).bits.psrc1
-    io.readState(3*i+1).req := io.fromDq(i).bits.psrc2
-    io.readState(3*i+2).req := io.fromDq(i).bits.psrc3
+    io.readState(3*i  ).req := io.fromDq(i).bits.psrc(0)
+    io.readState(3*i+1).req := io.fromDq(i).bits.psrc(1)
+    io.readState(3*i+2).req := io.fromDq(i).bits.psrc(2)
   }
-  io.readRf(0)  := io.enqIQCtrl(0).bits.psrc1
-  io.readRf(1)  := io.enqIQCtrl(0).bits.psrc2
-  io.readRf(2)  := io.enqIQCtrl(0).bits.psrc3
-  io.readRf(3)  := io.enqIQCtrl(1).bits.psrc1
-  io.readRf(4)  := io.enqIQCtrl(1).bits.psrc2
-  io.readRf(5)  := io.enqIQCtrl(1).bits.psrc3
-  io.readRf(6)  := Mux(io.enqIQCtrl(2).valid, io.enqIQCtrl(2).bits.psrc1, io.enqIQCtrl(4).bits.psrc1)
-  io.readRf(7)  := Mux(io.enqIQCtrl(2).valid, io.enqIQCtrl(2).bits.psrc2, io.enqIQCtrl(4).bits.psrc2)
-  io.readRf(8)  := Mux(io.enqIQCtrl(2).valid, io.enqIQCtrl(2).bits.psrc3, io.enqIQCtrl(4).bits.psrc3)
-  io.readRf(9)  := Mux(io.enqIQCtrl(3).valid, io.enqIQCtrl(3).bits.psrc1, io.enqIQCtrl(5).bits.psrc1)
-  io.readRf(10) := Mux(io.enqIQCtrl(3).valid, io.enqIQCtrl(3).bits.psrc2, io.enqIQCtrl(5).bits.psrc2)
-  io.readRf(11) := Mux(io.enqIQCtrl(3).valid, io.enqIQCtrl(3).bits.psrc3, io.enqIQCtrl(5).bits.psrc3)
+  io.readRf(0)  := io.enqIQCtrl(0).bits.psrc(0)
+  io.readRf(1)  := io.enqIQCtrl(0).bits.psrc(1)
+  io.readRf(2)  := io.enqIQCtrl(0).bits.psrc(2)
+  io.readRf(3)  := io.enqIQCtrl(1).bits.psrc(0)
+  io.readRf(4)  := io.enqIQCtrl(1).bits.psrc(1)
+  io.readRf(5)  := io.enqIQCtrl(1).bits.psrc(2)
+  io.readRf(6)  := Mux(io.enqIQCtrl(2).valid, io.enqIQCtrl(2).bits.psrc(0), io.enqIQCtrl(4).bits.psrc(0))
+  io.readRf(7)  := Mux(io.enqIQCtrl(2).valid, io.enqIQCtrl(2).bits.psrc(1), io.enqIQCtrl(4).bits.psrc(1))
+  io.readRf(8)  := Mux(io.enqIQCtrl(2).valid, io.enqIQCtrl(2).bits.psrc(2), io.enqIQCtrl(4).bits.psrc(2))
+  io.readRf(9)  := Mux(io.enqIQCtrl(3).valid, io.enqIQCtrl(3).bits.psrc(0), io.enqIQCtrl(5).bits.psrc(0))
+  io.readRf(10) := Mux(io.enqIQCtrl(3).valid, io.enqIQCtrl(3).bits.psrc(1), io.enqIQCtrl(5).bits.psrc(1))
+  io.readRf(11) := Mux(io.enqIQCtrl(3).valid, io.enqIQCtrl(3).bits.psrc(2), io.enqIQCtrl(5).bits.psrc(2))
 
   /**
     * Part 3: dispatch to reservation stations
@@ -96,12 +96,12 @@ class Dispatch2Fp(implicit p: Parameters) extends XSModule {
     val src1Ready = VecInit((0 until 4).map(i => io.readState(i * 3).resp))
     val src2Ready = VecInit((0 until 4).map(i => io.readState(i * 3 + 1).resp))
     val src3Ready = VecInit((0 until 4).map(i => io.readState(i * 3 + 2).resp))
-    enq.bits.src1State := src1Ready(deqIndex)
-    enq.bits.src2State := src2Ready(deqIndex)
-    enq.bits.src3State := src3Ready(deqIndex)
+    enq.bits.srcState(0) := src1Ready(deqIndex)
+    enq.bits.srcState(1) := src2Ready(deqIndex)
+    enq.bits.srcState(2) := src3Ready(deqIndex)
 
     XSInfo(enq.fire(), p"pc 0x${Hexadecimal(enq.bits.cf.pc)} with type ${enq.bits.ctrl.fuType} " +
-      p"srcState(${enq.bits.src1State} ${enq.bits.src2State} ${enq.bits.src3State}) " +
+      p"srcState(${enq.bits.srcState(0)} ${enq.bits.srcState(1)} ${enq.bits.srcState(2)}) " +
       p"enters reservation station $i from ${deqIndex}\n")
   }
 
@@ -142,9 +142,9 @@ class Dispatch2Fp(implicit p: Parameters) extends XSModule {
 //
 //    XSDebug(dataValidRegDebug(i),
 //      p"pc 0x${Hexadecimal(uopReg(i).cf.pc)} reads operands from " +
-//        p"(${readPortIndexReg(i)    }, ${uopReg(i).psrc1}, ${Hexadecimal(io.enqIQData(i).src1)}), " +
-//        p"(${readPortIndexReg(i)+1.U}, ${uopReg(i).psrc2}, ${Hexadecimal(io.enqIQData(i).src2)}), " +
-//        p"(${readPortIndexReg(i)+2.U}, ${uopReg(i).psrc3}, ${Hexadecimal(io.enqIQData(i).src3)})\n")
+//        p"(${readPortIndexReg(i)    }, ${uopReg(i).psrc(0)}, ${Hexadecimal(io.enqIQData(i).src1)}), " +
+//        p"(${readPortIndexReg(i)+1.U}, ${uopReg(i).psrc(1)}, ${Hexadecimal(io.enqIQData(i).src2)}), " +
+//        p"(${readPortIndexReg(i)+2.U}, ${uopReg(i).psrc(2)}, ${Hexadecimal(io.enqIQData(i).src3)})\n")
 //  }
 
   XSPerfAccumulate("in", PopCount(io.fromDq.map(_.valid)))

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch2Int.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch2Int.scala
@@ -58,24 +58,24 @@ class Dispatch2Int(implicit p: Parameters) extends XSModule {
   // val intDynamicMapped = intDynamicIndex.map(i => indexVec(i))
   // for (i <- intStaticIndex.indices) {
   //   val index = WireInit(VecInit(intStaticMapped(i) +: intDynamicMapped))
-  //   io.readRf(2*i  ) := io.fromDq(index(intReadPortSrc(i))).bits.psrc1
-  //   io.readRf(2*i+1) := io.fromDq(index(intReadPortSrc(i))).bits.psrc2
+  //   io.readRf(2*i  ) := io.fromDq(index(intReadPortSrc(i))).bits.psrc(0)
+  //   io.readRf(2*i+1) := io.fromDq(index(intReadPortSrc(i))).bits.psrc(1)
   // }
   // val readPortIndex = Wire(Vec(exuParameters.IntExuCnt, UInt(2.W)))
   // intStaticIndex.zipWithIndex.map({case (index, i) => readPortIndex(index) := i.U})
   // intDynamicIndex.zipWithIndex.map({case (index, i) => readPortIndex(index) := intDynamicExuSrc(i)})
-  io.readRf(0) := io.enqIQCtrl(3).bits.psrc1
-  io.readRf(1) := io.enqIQCtrl(3).bits.psrc2
-  io.readRf(2) := Mux(io.enqIQCtrl(4).valid, io.enqIQCtrl(4).bits.psrc1, io.enqIQCtrl(0).bits.psrc1)
-  io.readRf(3) := io.enqIQCtrl(4).bits.psrc2
-  io.readRf(4) := Mux(io.enqIQCtrl(5).valid, io.enqIQCtrl(5).bits.psrc1, io.enqIQCtrl(1).bits.psrc1)
-  io.readRf(5) := Mux(io.enqIQCtrl(5).valid, io.enqIQCtrl(5).bits.psrc2, io.enqIQCtrl(1).bits.psrc2)
-  io.readRf(6) := Mux(io.enqIQCtrl(6).valid, io.enqIQCtrl(6).bits.psrc1, io.enqIQCtrl(2).bits.psrc1)
-  io.readRf(7) := Mux(io.enqIQCtrl(6).valid, io.enqIQCtrl(6).bits.psrc2, io.enqIQCtrl(2).bits.psrc2)
+  io.readRf(0) := io.enqIQCtrl(3).bits.psrc(0)
+  io.readRf(1) := io.enqIQCtrl(3).bits.psrc(1)
+  io.readRf(2) := Mux(io.enqIQCtrl(4).valid, io.enqIQCtrl(4).bits.psrc(0), io.enqIQCtrl(0).bits.psrc(0))
+  io.readRf(3) := io.enqIQCtrl(4).bits.psrc(1)
+  io.readRf(4) := Mux(io.enqIQCtrl(5).valid, io.enqIQCtrl(5).bits.psrc(0), io.enqIQCtrl(1).bits.psrc(0))
+  io.readRf(5) := Mux(io.enqIQCtrl(5).valid, io.enqIQCtrl(5).bits.psrc(1), io.enqIQCtrl(1).bits.psrc(1))
+  io.readRf(6) := Mux(io.enqIQCtrl(6).valid, io.enqIQCtrl(6).bits.psrc(0), io.enqIQCtrl(2).bits.psrc(0))
+  io.readRf(7) := Mux(io.enqIQCtrl(6).valid, io.enqIQCtrl(6).bits.psrc(1), io.enqIQCtrl(2).bits.psrc(1))
 
   for (i <- 0 until dpParams.IntDqDeqWidth) {
-    io.readState(2*i  ).req := io.fromDq(i).bits.psrc1
-    io.readState(2*i+1).req := io.fromDq(i).bits.psrc2
+    io.readState(2*i  ).req := io.fromDq(i).bits.psrc(0)
+    io.readState(2*i+1).req := io.fromDq(i).bits.psrc(1)
   }
   val src1Ready = VecInit((0 until 4).map(i => io.readState(i * 2).resp))
   val src2Ready = VecInit((0 until 4).map(i => io.readState(i * 2 + 1).resp))
@@ -100,12 +100,12 @@ class Dispatch2Int(implicit p: Parameters) extends XSModule {
     }
     enq.bits := io.fromDq(deqIndex).bits
 
-    enq.bits.src1State := src1Ready(deqIndex)
-    enq.bits.src2State := src2Ready(deqIndex)
-    enq.bits.src3State := DontCare
+    enq.bits.srcState(0) := src1Ready(deqIndex)
+    enq.bits.srcState(1) := src2Ready(deqIndex)
+    enq.bits.srcState(2) := DontCare
 
     XSInfo(enq.fire(), p"pc 0x${Hexadecimal(enq.bits.cf.pc)} with type ${enq.bits.ctrl.fuType} " +
-      p"srcState(${enq.bits.src1State} ${enq.bits.src2State}) " +
+      p"srcState(${enq.bits.srcState(0)} ${enq.bits.srcState(1)}) " +
       p"enters reservation station $i from ${deqIndex}\n")
   }
 
@@ -141,15 +141,15 @@ class Dispatch2Int(implicit p: Parameters) extends XSModule {
 //    dataValidRegDebug(i) := io.enqIQCtrl(i).fire()
 //
 //    io.enqIQData(i) := DontCare
-//    io.enqIQData(i).src1 := Mux(uopReg(i).ctrl.src1Type === SrcType.pc,
+//    io.enqIQData(i).src1 := Mux(uopReg(i).ctrl.srcType(0) === SrcType.pc,
 //      SignExt(uopReg(i).cf.pc, XLEN), io.readRf(readPortIndexReg(i)).data)
-//    io.enqIQData(i).src2 := Mux(uopReg(i).ctrl.src2Type === SrcType.imm,
+//    io.enqIQData(i).src2 := Mux(uopReg(i).ctrl.srcType(1) === SrcType.imm,
 //      uopReg(i).ctrl.imm, io.readRf(readPortIndexReg(i) + 1.U).data)
 //
 //    XSDebug(dataValidRegDebug(i),
 //      p"pc 0x${Hexadecimal(uopReg(i).cf.pc)} reads operands from " +
-//        p"(${readPortIndexReg(i)    }, ${uopReg(i).psrc1}, ${Hexadecimal(io.enqIQData(i).src1)}), " +
-//        p"(${readPortIndexReg(i)+1.U}, ${uopReg(i).psrc2}, ${Hexadecimal(io.enqIQData(i).src2)})\n")
+//        p"(${readPortIndexReg(i)    }, ${uopReg(i).psrc(0)}, ${Hexadecimal(io.enqIQData(i).src1)}), " +
+//        p"(${readPortIndexReg(i)+1.U}, ${uopReg(i).psrc(1)}, ${Hexadecimal(io.enqIQData(i).src2)})\n")
 //  }
 
   XSPerfAccumulate("in", PopCount(io.fromDq.map(_.valid)))

--- a/src/main/scala/xiangshan/backend/fu/Fence.scala
+++ b/src/main/scala/xiangshan/backend/fu/Fence.scala
@@ -39,15 +39,13 @@ class Fence(implicit p: Parameters) extends FunctionUnit{ // TODO: check it
   val sbEmpty = toSbuffer.sbIsEmpty
   val uop = RegEnable(io.in.bits.uop, io.in.fire())
   val func = uop.ctrl.fuOpType
-  val lsrc1 = uop.ctrl.lsrc1
-  val lsrc2 = uop.ctrl.lsrc2
 
   // NOTE: icache & tlb & sbuffer must receive flush signal at any time
   sbuffer      := state === s_wait
   fencei       := state === s_icache
   sfence.valid := state === s_tlb
-  sfence.bits.rs1  := lsrc1 === 0.U
-  sfence.bits.rs2  := lsrc2 === 0.U
+  sfence.bits.rs1  := uop.ctrl.lsrc(0) === 0.U
+  sfence.bits.rs2  := uop.ctrl.lsrc(1) === 0.U
   sfence.bits.addr := RegEnable(src1, io.in.fire())
 
   when (state === s_idle && valid) { state := s_wait }

--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -563,9 +563,9 @@ class ReservationStationCtrl
     (srcType =/= SrcType.reg && srcType =/= SrcType.fp) ||
     (srcType === SrcType.reg && src === 0.U)
   }
-  val enqSrcSeq      = Seq(enqUop.psrc1, enqUop.psrc2, enqUop.psrc3)
-  val enqSrcTypeSeq  = Seq(enqUop.ctrl.src1Type, enqUop.ctrl.src2Type, enqUop.ctrl.src3Type)
-  val enqSrcStateSeq = Seq(enqUop.src1State, enqUop.src2State, enqUop.src3State)
+  val enqSrcSeq      = Seq(enqUop.psrc(0), enqUop.psrc(1), enqUop.psrc(2))
+  val enqSrcTypeSeq  = Seq(enqUop.ctrl.srcType(0), enqUop.ctrl.srcType(1), enqUop.ctrl.srcType(2))
+  val enqSrcStateSeq = Seq(enqUop.srcState(0), enqUop.srcState(1), enqUop.srcState(2))
   val enqSrcReady = (0 until srcNum).map(i =>
     stateCheck(enqSrcSeq(i), enqSrcTypeSeq(i)) || (enqSrcStateSeq(i) === SrcState.rdy)
   )
@@ -591,11 +591,11 @@ class ReservationStationCtrl
   }
   // NOTE: delay one cycle for fp src will come one cycle later than usual
   if (exuCfg == StExeUnitCfg) {
-    when (enqEnReg && RegNext(enqUop.ctrl.src2Type === SrcType.fp && enqSrcReady(1))) {
+    when (enqEnReg && RegNext(enqUop.ctrl.srcType(1) === SrcType.fp && enqSrcReady(1))) {
       srcQueue(enqPtrReg)(1) := true.B
     }
     when (enqEn) {
-      when (enqUop.ctrl.src2Type === SrcType.fp) { srcQueue(enqPtr)(1) := false.B }
+      when (enqUop.ctrl.srcType(1) === SrcType.fp) { srcQueue(enqPtr)(1) := false.B }
     }
   }
   val srcQueueWire = VecInit((0 until srcQueue.size).map(i => {
@@ -919,7 +919,7 @@ class ReservationStationData
 
   exuCfg match {
     case JumpExeUnitCfg =>
-      val src1Mux = Mux(enqUopReg.ctrl.src1Type === SrcType.pc,
+      val src1Mux = Mux(enqUopReg.ctrl.srcType(0) === SrcType.pc,
                         SignExt(io.jumpPc, XLEN),
                         io.srcRegValue(0)
                     )
@@ -935,7 +935,7 @@ class ReservationStationData
                     ImmUnion.I.toImm32(enqUopReg.ctrl.imm)
                   )
       val imm64 = SignExt(imm32, XLEN)
-      val src2Mux = Mux(enqUopReg.ctrl.src2Type === SrcType.imm,
+      val src2Mux = Mux(enqUopReg.ctrl.srcType(1) === SrcType.imm,
                       imm64, io.srcRegValue(1)
                     )
       data(1).w(0).wdata := src2Mux
@@ -944,8 +944,8 @@ class ReservationStationData
       (0 until srcNum).foreach(i => data(i).w(0).wdata := io.srcRegValue(i) )
       data(1).w(1).wdata := io.fpRegValue
       data(1).w(1).addr := RegNext(addrReg)
-      data(1).w(1).wen   := RegNext(enqSrcReadyReg(1) && enqUopReg.ctrl.src2Type === SrcType.fp)
-      data(1).w(0).wen   := enqSrcReadyReg(1) && enqUopReg.ctrl.src2Type =/= SrcType.fp
+      data(1).w(1).wen   := RegNext(enqSrcReadyReg(1) && enqUopReg.ctrl.srcType(1) === SrcType.fp)
+      data(1).w(0).wen   := enqSrcReadyReg(1) && enqUopReg.ctrl.srcType(1) =/= SrcType.fp
 
     case _ =>
       (0 until srcNum).foreach(i => data(i).w(0).wdata := io.srcRegValue(i) )


### PR DESCRIPTION
This commit uses Vec for lsrc, psrc, srcState and srcType in MicroOp bundle.
This makes uop easier to access.