### PR TITLE
DispatchQueue: wrap around tailPtr index when redirect

### DIFF
--- a/src/main/scala/xiangshan/backend/dispatch/DispatchQueue.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/DispatchQueue.scala
@@ -138,7 +138,8 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int, name: String)(implicit 
   val loValidBitVec = Cat((0 until size).map(i => validBitVec(i) && headPtrMask(i)))
   val hiValidBitVec = Cat((0 until size).map(i => validBitVec(i) && ~headPtrMask(i)))
   val flippedFlag = loValidBitVec.orR || validBitVec(size - 1)
-  val lastOneIndex = size.U - PriorityEncoder(Mux(loValidBitVec.orR, loValidBitVec, hiValidBitVec))
+  val leadingZeros = PriorityEncoder(Mux(loValidBitVec.orR, loValidBitVec, hiValidBitVec))
+  val lastOneIndex = Mux(leadingZeros === 0.U, 0.U, size.U - leadingZeros)
   val walkedTailPtr = Wire(new DispatchQueuePtr)
   walkedTailPtr.flag := flippedFlag ^ headPtr(0).flag
   walkedTailPtr.value := lastOneIndex


### PR DESCRIPTION
This commit fixes the bug when redirect.valid and the last valid instruction is in the last slot.
Previously the tailPtr becomes size.U when there're no instructions before headPtr. It works fine
when DispatchQueueSize is power2.