### PR TITLE
Config: add MinimalConfig

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -12,11 +12,11 @@ case class SoCParameters
 (
   cores: List[XSCoreParameters],
   EnableILA: Boolean = false,
-  extIntrs: Int = 150
+  extIntrs: Int = 150,
+  useFakeL3Cache: Boolean = false
 ){
   val PAddrBits = cores.map(_.PAddrBits).reduce((x, y) => if(x > y) x else y)
   // L3 configurations
-  val useFakeL3Cache = false
   val L3InnerBusWidth = 256
   val L3Size = 4 * 1024 * 1024 // 4MB
   val L3BlockSize = 64

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -1,0 +1,73 @@
+package top
+
+import chipsalliance.rocketchip.config.{Config, Parameters}
+import system.SoCParamsKey
+import xiangshan.DebugOptionsKey
+
+import scala.annotation.tailrec
+import scala.sys.exit
+
+object ArgParser {
+  // TODO: add more explainations
+  val usage =
+    """
+      |XiangShan Options
+      |--xs-help                  print this help message
+      |--config <ConfigClassName>
+      |--num-cores <Int>
+      |--dual-core                same as '--num-cores 2'
+      |--with-dramsim3
+      |--disable-log
+      |--disable-perf
+      |""".stripMargin
+
+  def getConfigByName(confString: String): Parameters = {
+    var prefix = "top." // default package is 'top'
+    if(confString.contains('.')){ // already a full name
+      prefix = ""
+    }
+    val c = Class.forName(prefix + confString).getConstructor(Integer.TYPE)
+    c.newInstance(1.asInstanceOf[Object]).asInstanceOf[Parameters]
+  }
+  def parse(args: Array[String]): (Parameters, Array[String]) = {
+    val default = new DefaultConfig(1)
+    var firrtlOpts = Array[String]()
+    @tailrec
+    def nextOption(config: Parameters, list: List[String]): Parameters = {
+      list match {
+        case Nil => config
+        case "--xs-help" :: tail =>
+          println(usage)
+          if(tail == Nil) exit(0)
+          nextOption(config, tail)
+        case "--config" :: confString :: tail =>
+          nextOption(getConfigByName(confString), tail)
+        case "--num-cores" :: value :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case SoCParamsKey => up(SoCParamsKey).copy(
+              cores = List.tabulate(value.toInt){ i => up(SoCParamsKey).cores.head.copy(HartId = i) }
+            )
+          }), tail)
+        case "--dual-core" :: tail =>
+          nextOption(config, "--num-cores" :: "2" :: tail)
+        case "--with-dramsim3" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case DebugOptionsKey => up(DebugOptionsKey).copy(UseDRAMSim = true)
+          }), tail)
+        case "--disable-log" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case DebugOptionsKey => up(DebugOptionsKey).copy(EnableDebug = false)
+          }), tail)
+        case "--disable-perf" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case DebugOptionsKey => up(DebugOptionsKey).copy(EnablePerfDebug = false)
+          }), tail)
+        case option :: tail =>
+          // unknown option, maybe a firrtl option, skip
+          firrtlOpts :+= option
+          nextOption(config, tail)
+      }
+    }
+    (nextOption(default, args.toList), firrtlOpts)
+  }
+}

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -29,7 +29,7 @@ object ArgParser {
     val c = Class.forName(prefix + confString).getConstructor(Integer.TYPE)
     c.newInstance(1.asInstanceOf[Object]).asInstanceOf[Parameters]
   }
-  def parse(args: Array[String]): (Parameters, Array[String]) = {
+  def parse(args: Array[String], fpga: Boolean = true): (Parameters, Array[String]) = {
     val default = new DefaultConfig(1)
     var firrtlOpts = Array[String]()
     @tailrec
@@ -68,6 +68,12 @@ object ArgParser {
           nextOption(config, tail)
       }
     }
-    (nextOption(default, args.toList), firrtlOpts)
+    var config = nextOption(default, args.toList)
+    if(!fpga){
+      config = config.alter((site, here, up) => {
+        case DebugOptionsKey => up(DebugOptionsKey).copy(FPGAPlatform = false)
+      })
+    }
+    (config, firrtlOpts)
   }
 }

--- a/src/main/scala/top/Config.scala
+++ b/src/main/scala/top/Config.scala
@@ -1,0 +1,48 @@
+package top
+
+import chisel3._
+import chisel3.util._
+import xiangshan._
+import utils._
+import system._
+import chipsalliance.rocketchip.config._
+import freechips.rocketchip.tile.{BusErrorUnit, BusErrorUnitParams, XLen}
+import sifive.blocks.inclusivecache.{InclusiveCache, InclusiveCacheMicroParameters, CacheParameters}
+import xiangshan.backend.dispatch.DispatchParameters
+import xiangshan.cache.{DCacheParameters, ICacheParameters, L1plusCacheParameters}
+import xiangshan.cache.prefetch.{BOPParameters, L1plusPrefetcherParameters, L2PrefetcherParameters, StreamPrefetchParameters}
+
+class DefaultConfig(n: Int) extends Config((site, here, up) => {
+  case XLen => 64
+  case DebugOptionsKey => DebugOptions()
+  case SoCParamsKey => SoCParameters(
+    cores = List.tabulate(n){ i => XSCoreParameters(HartId = i) }
+  )
+})
+
+class MinimalConfig(n: Int) extends Config((site, here, up) => {
+  case XLen => 64
+  case DebugOptionsKey => DebugOptions()
+  case SoCParamsKey => SoCParameters(
+    cores = List.tabulate(n){ i => XSCoreParameters(
+      IssQueSize = 8,
+      NRPhyRegs = 80,
+      LoadQueueSize = 16,
+      StoreQueueSize = 16,
+      RoqSize = 32,
+      BrqSize = 8,
+      FtqSize = 16,
+      IBufSize = 16,
+      dpParams = DispatchParameters(
+        IntDqSize = 8,
+        FpDqSize = 8,
+        LsDqSize = 8,
+        IntDqDeqWidth = 4,
+        FpDqDeqWidth = 4,
+        LsDqDeqWidth = 4
+      ),
+      EnableBPD = false, // disable TAGE
+      EnableLoop = false,
+    )
+  })
+})

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -20,29 +20,31 @@ class DefaultConfig(n: Int) extends Config((site, here, up) => {
   )
 })
 
-class MinimalConfig(n: Int) extends Config((site, here, up) => {
-  case XLen => 64
-  case DebugOptionsKey => DebugOptions()
-  case SoCParamsKey => SoCParameters(
-    cores = List.tabulate(n){ i => XSCoreParameters(
-      IssQueSize = 8,
-      NRPhyRegs = 80,
-      LoadQueueSize = 16,
-      StoreQueueSize = 16,
-      RoqSize = 32,
-      BrqSize = 8,
-      FtqSize = 16,
-      IBufSize = 16,
-      dpParams = DispatchParameters(
-        IntDqSize = 8,
-        FpDqSize = 8,
-        LsDqSize = 8,
-        IntDqDeqWidth = 4,
-        FpDqDeqWidth = 4,
-        LsDqDeqWidth = 4
-      ),
-      EnableBPD = false, // disable TAGE
-      EnableLoop = false,
+// TODO: disable L2 and L3
+class MinimalConfig(n: Int = 1) extends Config(
+  new DefaultConfig(n).alter((site, here, up) => {
+    case SoCParamsKey => up(SoCParamsKey).copy(
+      cores = up(SoCParamsKey).cores.map(_.copy(
+        HasL2Cache = false,
+        IssQueSize = 8,
+        NRPhyRegs = 80,
+        LoadQueueSize = 16,
+        StoreQueueSize = 16,
+        RoqSize = 32,
+        BrqSize = 8,
+        FtqSize = 16,
+        IBufSize = 16,
+        dpParams = DispatchParameters(
+          IntDqSize = 8,
+          FpDqSize = 8,
+          LsDqSize = 8,
+          IntDqDeqWidth = 4,
+          FpDqDeqWidth = 4,
+          LsDqDeqWidth = 4
+        ),
+        EnableBPD = false, // disable TAGE
+        EnableLoop = false,
+      ))
     )
   })
-})
+)

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -25,7 +25,6 @@ class MinimalConfig(n: Int = 1) extends Config(
   new DefaultConfig(n).alter((site, here, up) => {
     case SoCParamsKey => up(SoCParamsKey).copy(
       cores = up(SoCParamsKey).cores.map(_.copy(
-        HasL2Cache = false,
         IssQueSize = 8,
         NRPhyRegs = 80,
         LoadQueueSize = 16,
@@ -44,7 +43,17 @@ class MinimalConfig(n: Int = 1) extends Config(
         ),
         EnableBPD = false, // disable TAGE
         EnableLoop = false,
-      ))
+        TlbEntrySize = 4,
+        TlbSPEntrySize = 2,
+        PtwL1EntrySize = 2,
+        PtwL2EntrySize = 2,
+        PtwL3EntrySize = 4,
+        PtwSPEntrySize = 2,
+        useFakeDCache = true,
+        useFakePTW = true,
+        useFakeL1plusCache = true,
+      )),
+      useFakeL3Cache = true
     )
   })
 )

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -321,12 +321,10 @@ class XSTopWithoutDMA()(implicit p: Parameters) extends BaseXSSoc()
 
 object TopMain extends App {
   override def main(args: Array[String]): Unit = {
-    val numCores = if(args.contains("--dual-core")) 2 else 1
-    val otherArgs = args.filterNot(_ == "--dual-core")
-    implicit val config = new DefaultConfig(numCores)
-    XiangShanStage.execute(otherArgs, Seq(
+    val (config, firrtlOpts) = ArgParser.parse(args)
+    XiangShanStage.execute(firrtlOpts, Seq(
       ChiselGeneratorAnnotation(() => {
-        val soc = LazyModule(new XSTop())
+        val soc = LazyModule(new XSTop()(config))
         soc.module
       })
     ))

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -319,14 +319,6 @@ class XSTopWithoutDMA()(implicit p: Parameters) extends BaseXSSoc()
   }
 }
 
-class DefaultConfig(n: Int) extends Config((site, here, up) => {
-  case XLen => 64
-  case DebugOptionsKey => DebugOptions()
-  case SoCParamsKey => SoCParameters(
-    cores = List.tabulate(n){ i => XSCoreParameters(HartId = i) }
-  )
-})
-
 object TopMain extends App {
   override def main(args: Array[String]): Unit = {
     val numCores = if(args.contains("--dual-core")) 2 else 1

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -23,7 +23,6 @@ case class XSCoreParameters
   HasDiv: Boolean = true,
   HasICache: Boolean = true,
   HasDCache: Boolean = true,
-  EnableStoreQueue: Boolean = true,
   AddrBits: Int = 64,
   VAddrBits: Int = 39,
   PAddrBits: Int = 40,
@@ -138,7 +137,6 @@ trait HasXSParameter {
   val HasDiv = coreParams.HasDiv
   val HasIcache = coreParams.HasICache
   val HasDcache = coreParams.HasDCache
-  val EnableStoreQueue = coreParams.EnableStoreQueue
   val AddrBits = coreParams.AddrBits // AddrBits is used in some cases
   val VAddrBits = coreParams.VAddrBits // VAddrBits is Virtual Memory addr bits
   val PAddrBits = coreParams.PAddrBits // PAddrBits is Phyical Memory addr bits

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -14,7 +14,6 @@ case object XSCoreParamsKey extends Field[XSCoreParameters]
 
 case class XSCoreParameters
 (
-  HasL2Cache: Boolean = false,
   HasPrefetch: Boolean = false,
   HartId: Int = 0,
   XLEN: Int = 64,
@@ -93,6 +92,9 @@ case class XSCoreParameters
   PtwL1EntrySize: Int = 16,
   PtwL2EntrySize: Int = 2048, //(256 * 8)
   NumPerfCounters: Int = 16,
+  useFakePTW: Boolean = false,
+  useFakeDCache: Boolean = false,
+  useFakeL1plusCache: Boolean = false
 ){
   val loadExuConfigs = Seq.fill(exuParameters.LduCnt)(LdExeUnitCfg)
   val storeExuConfigs = Seq.fill(exuParameters.StuCnt)(StExeUnitCfg)
@@ -195,7 +197,6 @@ trait HasXSParameter {
   val DTLBWidth = coreParams.LoadPipelineWidth + coreParams.StorePipelineWidth
   val TlbEntrySize = coreParams.TlbEntrySize
   val TlbSPEntrySize = coreParams.TlbSPEntrySize
-  val useFakePTW = false
   val PtwL3EntrySize = coreParams.PtwL3EntrySize
   val PtwSPEntrySize = coreParams.PtwSPEntrySize
   val PtwL1EntrySize = coreParams.PtwL1EntrySize
@@ -212,7 +213,6 @@ trait HasXSParameter {
     nMissEntries = 2
   )
 
-  val useFakeL1plusCache = false
   val l1plusCacheParameters = L1plusCacheParameters(
     tagECC = Some("secded"),
     dataECC = Some("secded"),
@@ -220,7 +220,6 @@ trait HasXSParameter {
     nMissEntries = 8
   )
 
-  val useFakeDCache = false
   val dcacheParameters = DCacheParameters(
     tagECC = Some("secded"),
     dataECC = Some("secded"),
@@ -237,6 +236,9 @@ trait HasXSParameter {
   // cache hierarchy configurations
   val l1BusDataWidth = 256
 
+  val useFakeDCache = coreParams.useFakeDCache
+  val useFakePTW = coreParams.useFakePTW
+  val useFakeL1plusCache = coreParams.useFakeL1plusCache
   // L2 configurations
   val useFakeL2Cache = useFakeDCache && useFakePTW && useFakeL1plusCache
   val L1BusWidth = 256

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -71,7 +71,7 @@ class SimTop(implicit p: Parameters) extends Module {
 object SimTop extends App {
 
   override def main(args: Array[String]): Unit = {
-    val (config, firrtlOpts) = ArgParser.parse(args)
+    val (config, firrtlOpts) = ArgParser.parse(args, fpga = false)
     // generate verilog
     XiangShanStage.execute(
       firrtlOpts,

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -71,31 +71,10 @@ class SimTop(implicit p: Parameters) extends Module {
 object SimTop extends App {
 
   override def main(args: Array[String]): Unit = {
-    val useDRAMSim = args.contains("--with-dramsim3")
-    val numCores = if(args.contains("--dual-core")) 2 else 1
-    val disableLog = args.contains("--disable-log")
-    val disablePerf = args.contains("--disable-perf")
-
-    val firrtlArgs = args.
-      filterNot(_ == "--with-dramsim3").
-      filterNot(_ == "--dual-core").
-      filterNot(_ == "--disable-log").
-      filterNot(_ == "--disable-perf")
-
-    val config = new DefaultConfig(numCores).alter((site, here, up) => {
-      case DebugOptionsKey =>
-        val default = up(DebugOptionsKey)
-        DebugOptions(
-          FPGAPlatform = false,
-          EnableDebug = if(disableLog) false else default.EnableDebug,
-          EnablePerfDebug = if(disablePerf) false else default.EnablePerfDebug,
-          UseDRAMSim = if(useDRAMSim) true else default.UseDRAMSim
-        )
-    })
-
+    val (config, firrtlOpts) = ArgParser.parse(args)
     // generate verilog
     XiangShanStage.execute(
-      firrtlArgs,
+      firrtlOpts,
       Seq(
         ChiselGeneratorAnnotation(() => new SimTop()(config))
       )


### PR DESCRIPTION
MinimalConfig limited queues' size, disabled TAGE to limit generated
verilog size

Usage: change `config = DefaultConfig` to `config = MinimalConfig`
in Top.scala / SimTop.scala