### PR TITLE
backend,rs: support numEnq and numDeq parameters

### DIFF
--- a/src/main/scala/xiangshan/backend/FloatBlock.scala
+++ b/src/main/scala/xiangshan/backend/FloatBlock.scala
@@ -131,7 +131,7 @@ class FloatBlock
       slowPorts.length,
       fixedDelay = certainLatency,
       fastWakeup = certainLatency >= 0,
-      feedback = false,1
+      feedback = false,1, 1
     ))
 
     rs.io.redirect <> redirect // TODO: remove it
@@ -153,7 +153,7 @@ class FloatBlock
 
     exeUnits(i).io.redirect <> redirect
     exeUnits(i).io.flush <> flush
-    exeUnits(i).io.fromFp <> rs.io.deq
+    exeUnits(i).io.fromFp <> rs.io.deq(0)
     // rs.io.memfeedback := DontCare
 
     rs.suggestName(s"rs_${cfg.name}")
@@ -165,8 +165,8 @@ class FloatBlock
     val inBlockUops = reservationStations.filter(x =>
       x.exuCfg.hasCertainLatency && x.exuCfg.writeFpRf
     ).map(x => {
-      val raw = WireInit(x.io.fastUopOut)
-      raw.valid := x.io.fastUopOut.valid && raw.bits.ctrl.fpWen
+      val raw = WireInit(x.io.fastUopOut(0))
+      raw.valid := x.io.fastUopOut(0).valid && raw.bits.ctrl.fpWen
       raw
     })
     rs.io.fastUopsIn <> inBlockUops
@@ -234,7 +234,7 @@ class FloatBlock
     difftest.io.fpr    := VecInit(fpRf.io.debug_rports.map(p => ieee(p.data)))
   }
 
-  val rsDeqCount = PopCount(reservationStations.map(_.io.deq.valid))
+  val rsDeqCount = PopCount(reservationStations.map(_.io.deq(0).valid))
   XSPerfAccumulate("fp_rs_deq_count", rsDeqCount)
   XSPerfHistogram("fp_rs_deq_count", rsDeqCount, true.B, 0, 6, 1)
 }

--- a/src/main/scala/xiangshan/backend/FloatBlock.scala
+++ b/src/main/scala/xiangshan/backend/FloatBlock.scala
@@ -131,22 +131,22 @@ class FloatBlock
       slowPorts.length,
       fixedDelay = certainLatency,
       fastWakeup = certainLatency >= 0,
-      feedback = false
+      feedback = false,1
     ))
 
     rs.io.redirect <> redirect // TODO: remove it
     rs.io.flush <> flush // TODO: remove it
     rs.io.numExist <> io.toCtrlBlock.numExist(i)
-    rs.io.fromDispatch <> io.fromCtrlBlock.enqIqCtrl(i)
+    rs.io.fromDispatch <> VecInit(io.fromCtrlBlock.enqIqCtrl(i))
 
     rs.io.srcRegValue := DontCare
     val src1Value = VecInit((0 until 4).map(i => fpRf.io.readPorts(i * 3).data))
     val src2Value = VecInit((0 until 4).map(i => fpRf.io.readPorts(i * 3 + 1).data))
     val src3Value = VecInit((0 until 4).map(i => fpRf.io.readPorts(i * 3 + 2).data))
 
-    rs.io.srcRegValue(0) := src1Value(readPortIndex(i))
-    rs.io.srcRegValue(1) := src2Value(readPortIndex(i))
-    if (cfg.fpSrcCnt > 2) rs.io.srcRegValue(2) := src3Value(readPortIndex(i))
+    rs.io.srcRegValue(0)(0) := src1Value(readPortIndex(i))
+    rs.io.srcRegValue(0)(1) := src2Value(readPortIndex(i))
+    if (cfg.fpSrcCnt > 2) rs.io.srcRegValue(0)(2) := src3Value(readPortIndex(i))
 
     rs.io.fastDatas <> inBlockFastPorts.map(_._2)
     rs.io.slowPorts <> slowPorts

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -153,7 +153,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
       slowPorts.length,
       fixedDelay = certainLatency,
       fastWakeup = certainLatency >= 0,
-      feedback = feedback, 1)
+      feedback = feedback, 1, 1)
     )
 
     rs.io.redirect <> redirect // TODO: remove it
@@ -222,7 +222,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     loadUnits(i).io.isFirstIssue  := reservationStations(i).io.isFirstIssue // NOTE: just for dtlb's perf cnt
     loadUnits(i).io.dtlb          <> dtlb.io.requestor(i)
     // get input form dispatch
-    loadUnits(i).io.ldin          <> reservationStations(i).io.deq
+    loadUnits(i).io.ldin          <> reservationStations(i).io.deq(0)
     // dcache access
     loadUnits(i).io.dcache        <> dcache.io.lsu.load(i)
     // forward
@@ -255,7 +255,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     stu.io.rsIdx       <> rs.io.rsIdx
     stu.io.isFirstIssue <> rs.io.isFirstIssue // NOTE: just for dtlb's perf cnt
     stu.io.dtlb        <> dtlbReq
-    stu.io.stin        <> rs.io.deq
+    stu.io.stin        <> rs.io.deq(0)
     stu.io.lsq         <> lsq.io.storeIn(i)
 
     // Lsq to load unit's rs
@@ -264,12 +264,12 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     lsq.io.storeDataIn(i) := rs.io.stData
 
     // sync issue info to rs
-    lsq.io.storeIssue(i).valid := rs.io.deq.valid
-    lsq.io.storeIssue(i).bits := rs.io.deq.bits
+    lsq.io.storeIssue(i).valid := rs.io.deq(0).valid
+    lsq.io.storeIssue(i).bits := rs.io.deq(0).bits
 
     // sync issue info to store set LFST
-    io.toCtrlBlock.stIn(i).valid := rs.io.deq.valid
-    io.toCtrlBlock.stIn(i).bits := rs.io.deq.bits
+    io.toCtrlBlock.stIn(i).valid := rs.io.deq(0).valid
+    io.toCtrlBlock.stIn(i).bits := rs.io.deq(0).bits
 
     io.toCtrlBlock.stOut(i).valid := stu.io.stout.valid
     io.toCtrlBlock.stOut(i).bits  := stu.io.stout.bits
@@ -323,21 +323,21 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
 
   val atomic_rs0  = exuParameters.LduCnt + 0
   val atomic_rs1  = exuParameters.LduCnt + 1
-  val st0_atomics = reservationStations(atomic_rs0).io.deq.valid && FuType.storeIsAMO(reservationStations(atomic_rs0).io.deq.bits.uop.ctrl.fuType)
-  val st1_atomics = reservationStations(atomic_rs1).io.deq.valid && FuType.storeIsAMO(reservationStations(atomic_rs1).io.deq.bits.uop.ctrl.fuType)
+  val st0_atomics = reservationStations(atomic_rs0).io.deq(0).valid && FuType.storeIsAMO(reservationStations(atomic_rs0).io.deq(0).bits.uop.ctrl.fuType)
+  val st1_atomics = reservationStations(atomic_rs1).io.deq(0).valid && FuType.storeIsAMO(reservationStations(atomic_rs1).io.deq(0).bits.uop.ctrl.fuType)
 
   val st0_data_atomics = reservationStations(atomic_rs0).io.stData.valid && FuType.storeIsAMO(reservationStations(atomic_rs0).io.stData.bits.uop.ctrl.fuType)
   val st1_data_atomics = reservationStations(atomic_rs1).io.stData.valid && FuType.storeIsAMO(reservationStations(atomic_rs1).io.stData.bits.uop.ctrl.fuType)
 
   when (st0_atomics) {
-    reservationStations(atomic_rs0).io.deq.ready := atomicsUnit.io.in.ready
+    reservationStations(atomic_rs0).io.deq(0).ready := atomicsUnit.io.in.ready
     storeUnits(0).io.stin.valid := false.B
 
     state := s_atomics_0
     assert(!st1_atomics)
   }
   when (st1_atomics) {
-    reservationStations(atomic_rs1).io.deq.ready := atomicsUnit.io.in.ready
+    reservationStations(atomic_rs1).io.deq(0).ready := atomicsUnit.io.in.ready
     storeUnits(1).io.stin.valid := false.B
 
     state := s_atomics_1
@@ -349,7 +349,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   }
 
   atomicsUnit.io.in.valid := st0_atomics || st1_atomics
-  atomicsUnit.io.in.bits  := Mux(st0_atomics, reservationStations(atomic_rs0).io.deq.bits, reservationStations(atomic_rs1).io.deq.bits)
+  atomicsUnit.io.in.bits  := Mux(st0_atomics, reservationStations(atomic_rs0).io.deq(0).bits, reservationStations(atomic_rs1).io.deq(0).bits)
   atomicsUnit.io.storeDataIn.valid := st0_data_atomics || st1_data_atomics
   atomicsUnit.io.storeDataIn.bits  := Mux(st0_data_atomics, reservationStations(atomic_rs0).io.stData.bits, reservationStations(atomic_rs1).io.stData.bits)
   atomicsUnit.io.rsIdx    := Mux(st0_atomics, reservationStations(atomic_rs0).io.rsIdx, reservationStations(atomic_rs1).io.rsIdx)
@@ -394,8 +394,8 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   io.memInfo.lqFull := RegNext(lsq.io.lqFull)
   io.memInfo.dcacheMSHRFull := RegNext(dcache.io.mshrFull)
 
-  val ldDeqCount = PopCount(reservationStations.take(2).map(_.io.deq.valid))
-  val stDeqCount = PopCount(reservationStations.drop(2).map(_.io.deq.valid))
+  val ldDeqCount = PopCount(reservationStations.take(2).map(_.io.deq(0).valid))
+  val stDeqCount = PopCount(reservationStations.drop(2).map(_.io.deq(0).valid))
   val rsDeqCount = ldDeqCount + stDeqCount
   XSPerfAccumulate("load_rs_deq_count", ldDeqCount)
   XSPerfHistogram("load_rs_deq_count", ldDeqCount, true.B, 1, 2, 1)

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -153,17 +153,17 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
       slowPorts.length,
       fixedDelay = certainLatency,
       fastWakeup = certainLatency >= 0,
-      feedback = feedback)
+      feedback = feedback, 1)
     )
 
     rs.io.redirect <> redirect // TODO: remove it
     rs.io.flush    <> io.fromCtrlBlock.flush // TODO: remove it
     rs.io.numExist <> io.toCtrlBlock.numExist(i)
-    rs.io.fromDispatch  <> io.fromCtrlBlock.enqIqCtrl(i)
+    rs.io.fromDispatch  <> VecInit(io.fromCtrlBlock.enqIqCtrl(i))
 
-    rs.io.srcRegValue(0) := io.fromIntBlock.readIntRf(readPortIndex(i)).data
+    rs.io.srcRegValue(0)(0) := io.fromIntBlock.readIntRf(readPortIndex(i)).data
     if (i >= exuParameters.LduCnt) {
-      rs.io.srcRegValue(1) := io.fromIntBlock.readIntRf(readPortIndex(i) + 1).data
+      rs.io.srcRegValue(0)(1) := io.fromIntBlock.readIntRf(readPortIndex(i) + 1).data
       rs.io.fpRegValue := io.fromFpBlock.readFpRf(i - exuParameters.LduCnt).data
     }
 

--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -41,7 +41,8 @@ class ReservationStation
   fixedDelay: Int,
   fastWakeup: Boolean,
   feedback: Boolean,
-  enqNum: Int
+  enqNum: Int,
+  deqNum: Int
 )(implicit p: Parameters) extends XSModule {
   val iqIdxWidth = log2Up(iqSize+1)
   val nonBlocked = if (exuCfg == MulDivExeUnitCfg) false else fixedDelay >= 0
@@ -52,7 +53,7 @@ class ReservationStation
     name = myName,
     numEntries = iqSize,
     numEnq = enqNum,
-    numDeq = 1,
+    numDeq = deqNum,
     numSrc = srcNum,
     dataBits = srcLen,
     dataIdBits = PhyRegIdxWidth,
@@ -74,7 +75,7 @@ class ReservationStation
     val srcRegValue = Vec(config.numEnq, Input(Vec(srcNum, UInt(srcLen.W))))
     val fpRegValue = if (config.delayedRf) Input(UInt(srcLen.W)) else null
     // deq
-    val deq = DecoupledIO(new ExuInput)
+    val deq = Vec(config.numDeq, DecoupledIO(new ExuInput))
     val stData = if (exuCfg == StExeUnitCfg) ValidIO(new StoreDataBundle) else null
 
     val stIssuePtr = if (config.checkWaitBit) Input(new SqPtr()) else null
@@ -82,7 +83,7 @@ class ReservationStation
     val jumpPc = if(exuCfg == JumpExeUnitCfg) Input(UInt(VAddrBits.W)) else null
     val jalr_target = if(exuCfg == JumpExeUnitCfg) Input(UInt(VAddrBits.W)) else null
 
-    val fastUopOut = ValidIO(new MicroOp)
+    val fastUopOut = Vec(config.numDeq, ValidIO(new MicroOp))
     val fastUopsIn = Vec(config.numFastWakeup, Flipped(ValidIO(new MicroOp)))
     val fastDatas = Vec(config.numFastWakeup, Input(UInt(srcLen.W)))
     val slowPorts = Vec(slowPortsCnt, Flipped(ValidIO(new ExuOutput)))
@@ -167,36 +168,38 @@ class ReservationStation
     */
   // select the issue instructions
   select.io.request := statusArray.io.canIssue
-  select.io.grant(0).ready := io.deq.ready
-  if (config.hasFeedback) {
-    statusArray.io.issueGranted(0).valid := select.io.grant(0).fire
-    statusArray.io.issueGranted(0).bits := select.io.grant(0).bits
-    statusArray.io.deqResp(0).valid := io.memfeedback.valid
-    statusArray.io.deqResp(0).bits.rsMask := UIntToOH(io.memfeedback.bits.rsIdx)
-    statusArray.io.deqResp(0).bits.success := io.memfeedback.bits.hit
+  for (i <- 0 until config.numDeq) {
+    select.io.grant(i).ready := io.deq(i).ready
+    if (config.hasFeedback) {
+      require(config.numDeq == 1)
+      statusArray.io.issueGranted(0).valid := select.io.grant(0).fire
+      statusArray.io.issueGranted(0).bits := select.io.grant(0).bits
+      statusArray.io.deqResp(0).valid := io.memfeedback.valid
+      statusArray.io.deqResp(0).bits.rsMask := UIntToOH(io.memfeedback.bits.rsIdx)
+      statusArray.io.deqResp(0).bits.success := io.memfeedback.bits.hit
+    }
+    else {
+      statusArray.io.issueGranted(i).valid := select.io.grant(i).fire
+      statusArray.io.issueGranted(i).bits := select.io.grant(i).bits
+      statusArray.io.deqResp(i).valid := select.io.grant(i).fire
+      statusArray.io.deqResp(i).bits.rsMask := select.io.grant(i).bits
+      statusArray.io.deqResp(i).bits.success := io.deq(i).ready
+    }
+    payloadArray.io.read(i).addr := select.io.grant(i).bits
+    if (fixedDelay >= 0) {
+      val wakeupQueue = Module(new WakeupQueue(fixedDelay))
+      val fuCheck = (if (exuCfg == MulDivExeUnitCfg) payloadArray.io.read(i).data.ctrl.fuType === FuType.mul else true.B)
+      wakeupQueue.io.in.valid := select.io.grant(i).fire && fuCheck
+      wakeupQueue.io.in.bits := payloadArray.io.read(i).data
+      wakeupQueue.io.redirect := io.redirect
+      wakeupQueue.io.flush := io.flush
+      io.fastUopOut(i) := wakeupQueue.io.out
+    }
+    else {
+      io.fastUopOut(i).valid := false.B
+      io.fastUopOut(i).bits := DontCare
+    }
   }
-  else {
-    statusArray.io.issueGranted(0).valid := select.io.grant(0).fire
-    statusArray.io.issueGranted(0).bits := select.io.grant(0).bits
-    statusArray.io.deqResp(0).valid := select.io.grant(0).fire
-    statusArray.io.deqResp(0).bits.rsMask := select.io.grant(0).bits
-    statusArray.io.deqResp(0).bits.success := io.deq.ready
-  }
-  payloadArray.io.read(0).addr := select.io.grant(0).bits
-  if (fixedDelay >= 0) {
-    val wakeupQueue = Module(new WakeupQueue(fixedDelay))
-    val fuCheck = (if (exuCfg == MulDivExeUnitCfg) payloadArray.io.read(0).data.ctrl.fuType === FuType.mul else true.B)
-    wakeupQueue.io.in.valid := select.io.grant(0).fire && fuCheck
-    wakeupQueue.io.in.bits := payloadArray.io.read(0).data
-    wakeupQueue.io.redirect := io.redirect
-    wakeupQueue.io.flush := io.flush
-    io.fastUopOut := wakeupQueue.io.out
-  }
-  else {
-    io.fastUopOut.valid := false.B
-    io.fastUopOut.bits := DontCare
-  }
-
   // select whether the source is from (whether regfile or imm)
   // for read-after-issue, it's done over the selected uop
   // for read-before-issue, it's done over the enqueue uop (and store the imm in dataArray to save space)
@@ -268,35 +271,38 @@ class ReservationStation
   /**
    * S1: read data from regfile
    */
-  dataArray.io.read(0).addr := select.io.grant(0).bits
-  // for read-before-issue, we need to bypass the enqueue data here
-  // for read-after-issue, we need to bypass the imm here
-  // check enq data bypass (another form of broadcast except that we know where it hits) here
-  // enqRegSelected: Vec(config.numEnq, Bool())
-  val enqRegSelected = VecInit(select.io.allocate.map(a => RegNext(a.bits) === select.io.grant(0).bits))
-  // enqSrcStateReg: Vec(config.numEnq, Vec(config.numSrc, Bool()))
-  // [i][j]: i-th enqueue, j-th source state
-  val enqSrcStateReg = RegNext(VecInit(statusArray.io.update.map(_.data.srcState)))
-  // enqBypassValid: Vec(config.numEnq, Vec(config.numSrc, Bool()))
-  val enqBypassValid = enqSrcStateReg.zip(enqRegSelected).map{ case (state, sel) => VecInit(state.map(_ && sel)) }
+  val s1_out = Wire(Vec(config.numDeq, Decoupled(new ExuInput)))
+  for (i <- 0 until config.numDeq) {
+    dataArray.io.read(i).addr := select.io.grant(i).bits
+    // for read-before-issue, we need to bypass the enqueue data here
+    // for read-after-issue, we need to bypass the imm here
+    // check enq data bypass (another form of broadcast except that we know where it hits) here
+    // enqRegSelected: Vec(config.numEnq, Bool())
+    val enqRegSelected = VecInit(select.io.allocate.map(a => RegNext(a.bits) === select.io.grant(i).bits))
+    // enqSrcStateReg: Vec(config.numEnq, Vec(config.numSrc, Bool()))
+    // [i][j]: i-th enqueue, j-th source state
+    val enqSrcStateReg = RegNext(VecInit(statusArray.io.update.map(_.data.srcState)))
+    // enqBypassValid: Vec(config.numEnq, Vec(config.numSrc, Bool()))
+    val enqBypassValid = enqSrcStateReg.zip(enqRegSelected).map{ case (state, sel) => VecInit(state.map(_ && sel)) }
 
-  // bypass data for config.numDeq
-  val deqBypassValid = Mux1H(enqRegSelected, enqBypassValid)
-  val deqBypassData = Mux1H(enqRegSelected, immBypassedData)
-  // dequeue data should be bypassed
-  val deqUop = payloadArray.io.read(0).data
-  val deqDataRead = dataArray.io.read(0).data
-  val deqData = VecInit(deqBypassValid.zip(deqBypassData).zip(deqDataRead).map {
-    case ((v, d), r) => Mux(v, d, r)
-  })
+    // bypass data for config.numDeq
+    val deqBypassValid = Mux1H(enqRegSelected, enqBypassValid)
+    val deqBypassData = Mux1H(enqRegSelected, immBypassedData)
+    // dequeue data should be bypassed
+    val deqUop = payloadArray.io.read(i).data
+    val deqDataRead = dataArray.io.read(i).data
+    val deqData = VecInit(deqBypassValid.zip(deqBypassData).zip(deqDataRead).map {
+      case ((v, d), r) => Mux(v, d, r)
+    })
 
-  val s1_out = Wire(Decoupled(new ExuInput))
-  s1_out.valid := select.io.grant(0).valid && !deqUop.roqIdx.needFlush(io.redirect, io.flush)
-  s1_out.bits := DontCare
-  for (i <- 0 until config.numSrc) {
-    s1_out.bits.src(i) := deqData(i)
+    s1_out(i).valid := select.io.grant(i).valid && !deqUop.roqIdx.needFlush(io.redirect, io.flush)
+    s1_out(i).bits := DontCare
+    for (j <- 0 until config.numSrc) {
+      s1_out(i).bits.src(j) := deqData(j)
+    }
+    s1_out(i).bits.uop := deqUop
   }
-  s1_out.bits.uop := deqUop
+
 
   /**
    * S1: detect bypass from fast wakeup
@@ -309,42 +315,44 @@ class ReservationStation
     }
   }
   val fastWakeupMatchRegVec = RegNext(fastWakeupMatchVec)
-  val targetFastWakeupMatch = Mux1H(select.io.grant(0).bits, fastWakeupMatchRegVec)
-  val wakeupBypassMask = Wire(Vec(config.numFastWakeup, Vec(config.numSrc, Bool())))
-  for (i <- 0 until config.numFastWakeup) {
-    wakeupBypassMask(i) := VecInit(targetFastWakeupMatch.map(_(i)))
-  }
-  // data: send to bypass network
-  // TODO: these should be done outside RS
-  val bypassNetwork = Module(new BypassNetwork(config.numSrc, config.numFastWakeup, config.dataBits, config.optBuf))
-  bypassNetwork.io.hold := !io.deq.ready
-  bypassNetwork.io.source := s1_out.bits.src.take(config.numSrc)
-  bypassNetwork.io.bypass.zip(wakeupBypassMask.zip(io.fastDatas)).map { case (by, (m, d)) =>
-    by.valid := m
-    by.data := d
-  }
+  for (i <- 0 until config.numDeq) {
+    val targetFastWakeupMatch = Mux1H(select.io.grant(i).bits, fastWakeupMatchRegVec)
+    val wakeupBypassMask = Wire(Vec(config.numFastWakeup, Vec(config.numSrc, Bool())))
+    for (j <- 0 until config.numFastWakeup) {
+      wakeupBypassMask(j) := VecInit(targetFastWakeupMatch.map(_(j)))
+    }
+    // data: send to bypass network
+    // TODO: these should be done outside RS
+    val bypassNetwork = Module(new BypassNetwork(config.numSrc, config.numFastWakeup, config.dataBits, config.optBuf))
+    bypassNetwork.io.hold := !io.deq(i).ready
+    bypassNetwork.io.source := s1_out(i).bits.src.take(config.numSrc)
+    bypassNetwork.io.bypass.zip(wakeupBypassMask.zip(io.fastDatas)).map { case (by, (m, d)) =>
+      by.valid := m
+      by.data := d
+    }
 
-  /**
-    * S2: to function units
-    */
-  // payload: send to function units
-  // TODO: these should be done outside RS
-  PipelineConnect(s1_out, io.deq, io.deq.ready || io.deq.bits.uop.roqIdx.needFlush(io.redirect, io.flush), false.B)
-  val pipeline_fire = s1_out.valid && io.deq.ready
-  if (config.hasFeedback) {
-    io.rsIdx := RegEnable(OHToUInt(select.io.grant(0).bits), pipeline_fire)
-    io.isFirstIssue := false.B
-  }
+    /**
+      * S2: to function units
+      */
+    // payload: send to function units
+    // TODO: these should be done outside RS
+    PipelineConnect(s1_out(i), io.deq(i), io.deq(i).ready || io.deq(i).bits.uop.roqIdx.needFlush(io.redirect, io.flush), false.B)
+    val pipeline_fire = s1_out(i).valid && io.deq(i).ready
+    if (config.hasFeedback) {
+      io.rsIdx := RegEnable(OHToUInt(select.io.grant(i).bits), pipeline_fire)
+      io.isFirstIssue := false.B
+    }
 
-  for (i <- 0 until config.numSrc) {
-    io.deq.bits.src(i) := bypassNetwork.io.target(i)
-  }
+    for (j <- 0 until config.numSrc) {
+      io.deq(i).bits.src(j) := bypassNetwork.io.target(j)
+    }
 
-  // legacy things
-  if (exuCfg == StExeUnitCfg) {
-    io.stData.valid := io.deq.valid
-    io.stData.bits.data := io.deq.bits.src(1)
-    io.stData.bits.uop := io.deq.bits.uop
+    // legacy things
+    if (exuCfg == StExeUnitCfg) {
+      io.stData.valid := io.deq(i).valid
+      io.stData.bits.data := io.deq(i).bits.src(1)
+      io.stData.bits.uop := io.deq(i).bits.uop
+    }
   }
 
   // logs
@@ -352,6 +360,8 @@ class ReservationStation
     XSDebug(dispatch.valid && !dispatch.ready, p"enq blocked, roqIdx ${dispatch.bits.roqIdx}\n")
     XSDebug(dispatch.fire(), p"enq fire, roqIdx ${dispatch.bits.roqIdx}, srcState ${Binary(dispatch.bits.srcState.asUInt)}\n")
   }
-  XSDebug(io.deq.fire(), p"deq fire, roqIdx ${io.deq.bits.uop.roqIdx}\n")
-  XSDebug(io.deq.valid && !io.deq.ready, p"deq blocked, roqIdx ${io.deq.bits.uop.roqIdx}\n")
+  for (deq <- io.deq) {
+    XSDebug(deq.fire(), p"deq fire, roqIdx ${deq.bits.uop.roqIdx}\n")
+    XSDebug(deq.valid && !deq.ready, p"deq blocked, roqIdx ${deq.bits.uop.roqIdx}\n")
+  }
 }


### PR DESCRIPTION
This PR adds support for numEnq and numDeq parameters for reservation stations. 
Currently we use 2 ALU reservation stations for 4 ALUs.